### PR TITLE
Support for "subdirs"

### DIFF
--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -295,7 +295,8 @@ impl Object {
     /// # }
     /// ```
     pub fn read(bucket: &str, file_name: &str) -> Result<Self, Error> {
-        let url = format!("{}/b/{}/o/{}", crate::BASE_URL, bucket, file_name);
+        let file_name_encoded = percent_encode(file_name);
+        let url = format!("{}/b/{}/o/{}", crate::BASE_URL, bucket, file_name_encoded);
         let client = reqwest::blocking::Client::new();
         let result: GoogleResponse<Self> = client
             .get(&url)
@@ -665,6 +666,14 @@ mod tests {
         let bucket = crate::read_test_bucket();
         Object::create(&bucket.name, &[0, 1], "test-read", "text/plain")?;
         Object::read(&bucket.name, "test-read")?;
+        Ok(())
+    }
+
+    #[test]
+    fn read_subdirs() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket();
+        Object::create(&bucket.name, &[0, 1], "test/read", "text/plain")?;
+        Object::read(&bucket.name, "test/read")?;
         Ok(())
     }
 


### PR DESCRIPTION
If you try and read a file with slashes it returned an error: 

`Reqwest(reqwest::Error { kind: Decode, source: Error("expected value", line: 1, column: 1) })',`

By encoding the slashes before creating the URL we can now read them.