### PR TITLE
fix parsing ListResponse with absent items

### DIFF
--- a/src/resources/common.rs
+++ b/src/resources/common.rs
@@ -61,6 +61,7 @@ pub enum Role {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ListResponse<T> {
+    #[serde(default = "Vec::new")]
     pub items: Vec<T>,
     pub next_page_token: Option<String>,
 }


### PR DESCRIPTION
When calling `Object::list_prefix` and there is nothing in a storage with prefix provided parser fails with Decode error.
This PR fixes that behaviour.