### PR TITLE
Implement object download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ dotenv =           { version = "0.15", default-features = false }
 openssl =          { version = "0.10", default-features = false }
 chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
 hex =              { version = "0.4",  default-features = false }
+bytes =            { version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ dotenv =           { version = "0.15", default-features = false }
 openssl =          { version = "0.10", default-features = false }
 chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
 hex =              { version = "0.4",  default-features = false }
-bytes =            { version = "0.5" }

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -347,7 +347,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn download(bucket: &str, file_name: &str) -> Result<bytes::Bytes, Error> {
+    pub fn download(bucket: &str, file_name: &str) -> Result<Vec<u8>, Error> {
         let url = format!(
             "{}/b/{}/o/{}?alt=media",
             crate::BASE_URL,
@@ -359,7 +359,7 @@ impl Object {
             .get(&url)
             .headers(crate::get_headers()?)
             .send()?
-            .bytes()?)
+            .bytes()?.to_vec())
     }
 
     /// Obtains a single object with the specified name in the specified bucket.
@@ -761,7 +761,7 @@ mod tests {
         Object::create(&bucket.name, content, "test-download", "application/octet-stream")?;
 
         let data = Object::download(&bucket.name, "test-download")?;
-        assert_eq!(data.as_ref(), content);
+        assert_eq!(data, content);
 
         Ok(())
     }


### PR DESCRIPTION
Hi! 👋 I'm working on a project that needs to connect to Google Cloud Storage, and your crate is the easiest to use that I've found so far, so thank you!

We needed a few more things though. This PR adds a function to download the contents of a file as `bytes::Bytes`; I didn't see any existing way to do that.

Please let me know if you'd like this implemented in a different way, I'm happy to make changes!