### PR TITLE
Change delete so that you don't have to read an object first

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@
 //! Removing a file
 //! ```rust,no_run
 //! # use cloud_storage::Object;
-//! let object = Object::read("mybucket", "myfile").unwrap();
-//! object.delete();
+//! Object::delete("mybucket", "myfile");
 //! ```
 #![forbid(unsafe_code, missing_docs)]
 

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -747,6 +747,28 @@ mod tests {
     }
 
     #[test]
+    fn delete_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
+        let bucket = crate::read_test_bucket();
+
+        let obj = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
+        let nonexistent_obj = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
+        obj.delete()?;
+
+        // Call delete again, which should fail because the object no longer exists
+
+        let delete_result = nonexistent_obj.delete();
+
+        if let Err(Error::Google(google_error_response)) = delete_result {
+            assert!(google_error_response.to_string().contains(
+                &format!("No such object: {}/{}", bucket.name, "test-delete")));
+        } else {
+            panic!("Expected a Google error, instead got {:?}", delete_result);
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn compose() -> Result<(), Box<dyn std::error::Error>> {
         let bucket = crate::read_test_bucket();
         let obj1 = Object::create(&bucket.name, &[0, 1], "test-compose-1", "text/plain")?;

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -368,22 +368,21 @@ impl Object {
         }
     }
 
-    /// Obtains a single object with the specified name in the specified bucket.
+    /// Deletes a single object with the specified name in the specified bucket.
     /// ### Example
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> { 
     /// use cloud_storage::Object;
     ///
-    /// let mut object = Object::read("my_bucket", "path/to/my/file.png")?;
-    /// object.delete();
+    /// Object::delete("my_bucket", "path/to/my/file.png")?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn delete(self) -> Result<(), Error> {
+    pub fn delete(bucket: &str, file_name: &str) -> Result<(), Error> {
         let url = format!("{}/b/{}/o/{}",
             crate::BASE_URL,
-            percent_encode(&self.bucket),
-            percent_encode(&self.name),
+            percent_encode(bucket),
+            percent_encode(file_name),
         );
         let client = reqwest::blocking::Client::new();
         let response = client.delete(&url).headers(crate::get_headers()?).send()?;
@@ -741,8 +740,13 @@ mod tests {
     #[test]
     fn delete() -> Result<(), Box<dyn std::error::Error>> {
         let bucket = crate::read_test_bucket();
-        let obj = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
-        obj.delete()?;
+        Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
+
+        Object::delete(&bucket.name, "test-delete")?;
+
+        let list = Object::list_prefix(&bucket.name, "test-delete")?;
+        assert!(list.is_empty());
+
         Ok(())
     }
 
@@ -750,17 +754,13 @@ mod tests {
     fn delete_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
         let bucket = crate::read_test_bucket();
 
-        let obj = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
-        let nonexistent_obj = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")?;
-        obj.delete()?;
+        let nonexistent_object = "test-delete-nonexistent";
 
-        // Call delete again, which should fail because the object no longer exists
-
-        let delete_result = nonexistent_obj.delete();
+        let delete_result = Object::delete(&bucket.name, nonexistent_object);
 
         if let Err(Error::Google(google_error_response)) = delete_result {
             assert!(google_error_response.to_string().contains(
-                &format!("No such object: {}/{}", bucket.name, "test-delete")));
+                &format!("No such object: {}/{}", bucket.name, nonexistent_object)));
         } else {
             panic!("Expected a Google error, instead got {:?}", delete_result);
         }

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -302,7 +302,7 @@ mod tests {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
-        let object = Object::create(
+        Object::create(
             &bucket.name,
             &[0, 1],
             "test-update",
@@ -323,7 +323,7 @@ mod tests {
         .unwrap();
         acl.entity = Entity::AllAuthenticatedUsers;
         acl.update().unwrap();
-        object.delete().unwrap();
+        Object::delete(&bucket.name, "test-update").unwrap();
         bucket.delete().unwrap();
     }
 
@@ -335,13 +335,13 @@ mod tests {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
-        let object = Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain").unwrap();
+        Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain").unwrap();
         ObjectAccessControl::create(&bucket.name, "test-delete", &new_bucket_access_control)
             .unwrap();
         let acl =
             ObjectAccessControl::read(&bucket.name, "test-delete", &Entity::AllUsers).unwrap();
         acl.delete().unwrap();
-        object.delete().unwrap();
+        Object::delete(&bucket.name, "test-delete").unwrap();
         bucket.delete().unwrap();
     }
 }


### PR DESCRIPTION
I didn't see a way to delete an object without first getting the object with `Object::read`; it'd be nice to not have to do that when you know the bucket and file name you want to delete.

I changed the API rather than adding to it; it's a bit unfortunate that now [`Object` isn't consistent with `ObjectAccessControl` and `Bucket`](https://github.com/ThouCheese/cloud-storage-rs/compare/master...integer32llc:delete-without-get?expand=1#diff-35e044a173a09fbfd04baf9e79b2a133L343-L345) :-/ I'd be happy to change this to add a function instead, but I wasn't sure what to name it since its name would have to differ from the method's name. `delete_by_name`? 