### PR TITLE
reqwest: reuse client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@ lazy_static::lazy_static! {
     /// debugging of which service account is currently used. It is of the type
     /// [ServiceAccount](service_account/struct.ServiceAccount.html).
     pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
+
+    static ref CLIENT: reqwest::Client = reqwest::Client::new();
 }
 
 /// A type alias where the error is set to be `cloud_storage::Error`.

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -566,7 +566,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = crate::SERVICE_ACCOUNT.project_id.clone();
         let query = [("project", project)];
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -606,7 +606,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = crate::SERVICE_ACCOUNT.project_id.clone();
         let query = [("project", project)];
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -650,7 +650,7 @@ impl Bucket {
     /// ```
     pub async fn read(name: &str) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, name);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -700,7 +700,7 @@ impl Bucket {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -746,7 +746,7 @@ impl Bucket {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -789,7 +789,7 @@ impl Bucket {
     /// ```
     pub async fn get_iam_policy(&self) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+        let result: GoogleResponse<IamPolicy> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -845,7 +845,7 @@ impl Bucket {
     /// ```
     pub async fn set_iam_policy(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+        let result: GoogleResponse<IamPolicy> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(iam)
@@ -888,7 +888,7 @@ impl Bucket {
             ));
         }
         let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, self.name);
-        let result: GoogleResponse<TestIamPermission> = reqwest::Client::new()
+        let result: GoogleResponse<TestIamPermission> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&[("permissions", permission)])

--- a/src/resources/bucket_access_control.rs
+++ b/src/resources/bucket_access_control.rs
@@ -117,7 +117,7 @@ impl BucketAccessControl {
         new_bucket_access_control: &NewBucketAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_bucket_access_control)
@@ -162,7 +162,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -203,7 +203,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -246,7 +246,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -289,7 +289,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/channel.rs
+++ b/src/resources/channel.rs
@@ -1,5 +1,3 @@
-
-
 pub struct Channel {
     pub id: String,
     pub resourceId: String,
@@ -18,10 +16,11 @@ impl Channel {
 
     pub async fn stop_async(&self) -> Result<(), crate::Error> {
         let url = format!("{}/channels/stop", crate::BASE_URL);
-        let response = reqwest::Client::new()
+        let response = create::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
-            .send().await?;
+            .send()
+            .await?;
         if response.status().is_success() {
             Ok(())
         } else {

--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -103,7 +103,7 @@ impl DefaultObjectAccessControl {
         new_acl: &NewDefaultObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_acl)
@@ -150,7 +150,7 @@ impl DefaultObjectAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -206,7 +206,7 @@ impl DefaultObjectAccessControl {
             bucket,
             entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -256,7 +256,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -306,7 +306,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -106,7 +106,7 @@ impl HmacKey {
         let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, 0.into());
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .query(&query)
@@ -155,7 +155,7 @@ impl HmacKey {
             crate::BASE_URL,
             crate::SERVICE_ACCOUNT.project_id
         );
-        let result: GoogleResponse<ListResponse> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -203,7 +203,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+        let result: GoogleResponse<HmacMeta> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -252,7 +252,7 @@ impl HmacKey {
             access_id
         );
         serde_json::to_string(&UpdateMeta { state })?;
-        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+        let result: GoogleResponse<HmacMeta> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&UpdateMeta { state })
@@ -300,7 +300,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -191,7 +191,7 @@ impl Object {
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_TYPE, mime_type.to_string().parse()?);
         headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .post(url)
             .headers(headers)
             .body(file.to_owned())
@@ -227,7 +227,7 @@ impl Object {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use cloud_storage::Object;
     ///
-    /// let file = reqwest::Client::new()
+    /// let file = crate::CLIENT
     ///     .get("https://my_domain.rs/nice_cat_photo.png")
     ///     .send()
     ///     .await?
@@ -263,7 +263,7 @@ impl Object {
         headers.insert(CONTENT_LENGTH, length.to_string().parse()?);
 
         let body = reqwest::Body::wrap_stream(stream);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .post(url)
             .headers(headers)
             .body(body)
@@ -389,7 +389,7 @@ impl Object {
                 query.push(("prefix", prefix.to_string()));
             };
 
-            let response = reqwest::Client::new()
+            let response = crate::CLIENT
                 .get(&url)
                 .query(&query)
                 .headers(headers)
@@ -442,7 +442,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -483,7 +483,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(reqwest::Client::new()
+        Ok(crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -512,7 +512,7 @@ impl Object {
     /// use cloud_storage::Object;
     ///
     /// let stream = Object::download_streamed("my_bucket", "path/to/my/file.png").await?;
-    /// for 
+    /// for
     /// # Ok(())
     /// # }
     /// ```
@@ -528,7 +528,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(reqwest::Client::new()
+        Ok(crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -557,7 +557,7 @@ impl Object {
             percent_encode(&self.bucket),
             percent_encode(&self.name),
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&self)
@@ -599,7 +599,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -662,7 +662,7 @@ impl Object {
             percent_encode(&bucket),
             percent_encode(&destination_object)
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(req)
@@ -716,7 +716,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .send()
@@ -772,7 +772,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<RewriteResponse> = reqwest::Client::new()
+        let result: GoogleResponse<RewriteResponse> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .send()
@@ -1068,7 +1068,6 @@ mod tests {
         // let data = data.next().await.flat_map(|part| part.into_iter()).collect();
         assert_eq!(data, content);
 
-
         Ok(())
     }
 
@@ -1156,7 +1155,7 @@ mod tests {
         let obj = Object::create(&bucket.name, &[0, 1], "test-rewrite", "text/plain").await?;
         let obj = obj.rewrite(&bucket.name, "test-rewritten").await?;
         let url = obj.download_url(100)?;
-        let download = reqwest::Client::new().head(&url).send().await?;
+        let download = crate::CLIENT.head(&url).send().await?;
         assert_eq!(download.status().as_u16(), 200);
         Ok(())
     }
@@ -1176,7 +1175,7 @@ mod tests {
             let _obj = Object::create(&bucket.name, &[0, 1], name, "text/plain").await?;
             let obj = Object::read(&bucket.name, &name).await.unwrap();
             let url = obj.download_url(100)?;
-            let download = reqwest::Client::new().head(&url).send().await?;
+            let download = crate::CLIENT.head(&url).send().await?;
             assert_eq!(download.status().as_u16(), 200);
         }
         Ok(())

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -116,7 +116,7 @@ impl ObjectAccessControl {
         new_object_access_control: &NewObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_object_access_control)
@@ -152,7 +152,7 @@ impl ObjectAccessControl {
     /// control access instead.
     pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -189,7 +189,7 @@ impl ObjectAccessControl {
             object,
             entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -226,7 +226,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -264,7 +264,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/token.rs
+++ b/src/token.rs
@@ -69,7 +69,7 @@ impl Token {
             ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
             ("assertion", &jwt),
         ];
-        let response: TokenResponse = reqwest::Client::new()
+        let response: TokenResponse = super::CLIENT
             .post("https://www.googleapis.com/oauth2/v4/token")
             .form(&body)
             .send()


### PR DESCRIPTION
Change-Id: I795e7202ca4c83bec5db1ce1054e072ab87d2894

Initializing Reqwest client on every request is inefficient. Reqwest is Sync + Send therefore adding cached lazy_static version. 