### PR TITLE
reqwest: add feature reqwest/rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,14 @@ categories = ["api-bindings", "web-programming"]
 # maintenance = { status = "actively-developed" }
 
 [features]
-default = []
+default = ["native-tls"]
 
 sync = ["reqwest/blocking"]
+native-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
-reqwest =          { version = "0.10", default-features = false, features = ["json", "default-tls", "stream", "trust-dns"] }
+reqwest =          { version = "0.10", default-features = false, features = ["json", "stream", "trust-dns"] }
 percent-encoding = { version = "2",    default-features = false }
 jsonwebtoken =     { version = "7",    default-features = false }
 serde =            { version = "1",    default-features = false, features = ["derive"] }


### PR DESCRIPTION
Change-Id: I12cda0fce9484ccaf9c4f3a0a63778e646b8970d

default-tls uses OpenSSL which pulls many unnecessary dependencies, using rustls-tls is more efficient. 
