### PR TITLE
reqwest: use trust-dns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 sync = ["reqwest/blocking"]
 
 [dependencies]
-reqwest =          { version = "0.10", default-features = false, features = ["json", "default-tls", "stream"] }
+reqwest =          { version = "0.10", default-features = false, features = ["json", "default-tls", "stream", "trust-dns"] }
 percent-encoding = { version = "2",    default-features = false }
 jsonwebtoken =     { version = "7",    default-features = false }
 serde =            { version = "1",    default-features = false, features = ["derive"] }


### PR DESCRIPTION
Change-Id: Ifa8a6ff93b35fcdc26b58d38be282f7caabb1594

Adding trust-dns to reqwest client. Trust DNS allows to cache DNS requests, this will save occasional DNS roundtrip which is usually handled by the operating system. 