### PR TITLE
resources: make object create accept vector of bytes

### DIFF
--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -297,7 +297,7 @@ mod tests {
         let bucket = crate::read_test_bucket().await;
         Object::create(
             &bucket.name,
-            &[0, 1],
+            vec![0, 1],
             "test-object-access-controls-create",
             "text/plain",
         )
@@ -321,7 +321,7 @@ mod tests {
         let bucket = crate::read_test_bucket().await;
         Object::create(
             &bucket.name,
-            &[0, 1],
+            vec![0, 1],
             "test-object-access-controls-list",
             "text/plain",
         )
@@ -337,7 +337,7 @@ mod tests {
         let bucket = crate::read_test_bucket().await;
         Object::create(
             &bucket.name,
-            &[0, 1],
+            vec![0, 1],
             "test-object-access-controls-read",
             "text/plain",
         )
@@ -371,7 +371,7 @@ mod tests {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
-        Object::create(&bucket.name, &[0, 1], "test-update", "text/plain")
+        Object::create(&bucket.name, vec![0, 1], "test-update", "text/plain")
             .await
             .unwrap();
         ObjectAccessControl::create(&bucket.name, "test-update", &new_bucket_access_control)
@@ -394,7 +394,7 @@ mod tests {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
-        Object::create(&bucket.name, &[0, 1], "test-delete", "text/plain")
+        Object::create(&bucket.name, vec![0, 1], "test-delete", "text/plain")
             .await
             .unwrap();
         ObjectAccessControl::create(&bucket.name, "test-delete", &new_bucket_access_control)
@@ -417,7 +417,7 @@ mod tests {
             let bucket = crate::read_test_bucket_sync();
             Object::create_sync(
                 &bucket.name,
-                &[0, 1],
+                vec![0, 1],
                 "test-object-access-controls-create",
                 "text/plain",
             )
@@ -439,7 +439,7 @@ mod tests {
             let bucket = crate::read_test_bucket_sync();
             Object::create_sync(
                 &bucket.name,
-                &[0, 1],
+                vec![0, 1],
                 "test-object-access-controls-list",
                 "text/plain",
             )
@@ -453,7 +453,7 @@ mod tests {
             let bucket = crate::read_test_bucket_sync();
             Object::create_sync(
                 &bucket.name,
-                &[0, 1],
+                vec![0, 1],
                 "test-object-access-controls-read",
                 "text/plain",
             )
@@ -484,7 +484,7 @@ mod tests {
                 entity: Entity::AllUsers,
                 role: Role::Reader,
             };
-            Object::create_sync(&bucket.name, &[0, 1], "test-update", "text/plain").unwrap();
+            Object::create_sync(&bucket.name, vec![0, 1], "test-update", "text/plain").unwrap();
             ObjectAccessControl::create_sync(
                 &bucket.name,
                 "test-update",
@@ -508,7 +508,7 @@ mod tests {
                 entity: Entity::AllUsers,
                 role: Role::Reader,
             };
-            Object::create_sync(&bucket.name, &[0, 1], "test-delete", "text/plain").unwrap();
+            Object::create_sync(&bucket.name, vec![0, 1], "test-delete", "text/plain").unwrap();
             ObjectAccessControl::create_sync(
                 &bucket.name,
                 "test-delete",


### PR DESCRIPTION
Change-Id: Ib0bb5113f721aa0699fe7354585b7a25c13362e7

Object::create `file.to_owned` allocates same provided file to a vector of bytes. In cases when a file is in hundreds of megabytes, it becomes inefficient, especially when "file" is not used afterwards. A client of the function should decide whether he needs "file" afterwards by making a clone of "file" before passing to `Object::create` function. 