### PR TITLE
Revert "reqwest: reuse client"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,6 @@ lazy_static::lazy_static! {
     /// debugging of which service account is currently used. It is of the type
     /// [ServiceAccount](service_account/struct.ServiceAccount.html).
     pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
-
-    static ref CLIENT: reqwest::Client = reqwest::Client::new();
 }
 
 /// A type alias where the error is set to be `cloud_storage::Error`.

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -566,7 +566,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = &crate::SERVICE_ACCOUNT.project_id;
         let query = [("project", project)];
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -606,7 +606,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = &crate::SERVICE_ACCOUNT.project_id;
         let query = [("project", project)];
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -650,7 +650,7 @@ impl Bucket {
     /// ```
     pub async fn read(name: &str) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, name);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -700,7 +700,7 @@ impl Bucket {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -746,7 +746,7 @@ impl Bucket {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -789,7 +789,7 @@ impl Bucket {
     /// ```
     pub async fn get_iam_policy(&self) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = crate::CLIENT
+        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -845,7 +845,7 @@ impl Bucket {
     /// ```
     pub async fn set_iam_policy(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = crate::CLIENT
+        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(iam)
@@ -888,7 +888,7 @@ impl Bucket {
             ));
         }
         let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, self.name);
-        let result: GoogleResponse<TestIamPermission> = crate::CLIENT
+        let result: GoogleResponse<TestIamPermission> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&[("permissions", permission)])

--- a/src/resources/bucket_access_control.rs
+++ b/src/resources/bucket_access_control.rs
@@ -117,7 +117,7 @@ impl BucketAccessControl {
         new_bucket_access_control: &NewBucketAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_bucket_access_control)
@@ -162,7 +162,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -203,7 +203,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -246,7 +246,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -289,7 +289,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/channel.rs
+++ b/src/resources/channel.rs
@@ -1,3 +1,5 @@
+
+
 pub struct Channel {
     pub id: String,
     pub resourceId: String,
@@ -16,11 +18,10 @@ impl Channel {
 
     pub async fn stop_async(&self) -> Result<(), crate::Error> {
         let url = format!("{}/channels/stop", crate::BASE_URL);
-        let response = create::CLIENT
+        let response = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
-            .send()
-            .await?;
+            .send().await?;
         if response.status().is_success() {
             Ok(())
         } else {

--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -103,7 +103,7 @@ impl DefaultObjectAccessControl {
         new_acl: &NewDefaultObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_acl)
@@ -150,7 +150,7 @@ impl DefaultObjectAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -206,7 +206,7 @@ impl DefaultObjectAccessControl {
             bucket,
             entity
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -256,7 +256,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -306,7 +306,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -106,7 +106,7 @@ impl HmacKey {
         let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, 0.into());
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(headers)
             .query(&query)
@@ -155,7 +155,7 @@ impl HmacKey {
             crate::BASE_URL,
             crate::SERVICE_ACCOUNT.project_id
         );
-        let result: GoogleResponse<ListResponse> = crate::CLIENT
+        let result: GoogleResponse<ListResponse> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -203,7 +203,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let result: GoogleResponse<HmacMeta> = crate::CLIENT
+        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -252,7 +252,7 @@ impl HmacKey {
             access_id
         );
         serde_json::to_string(&UpdateMeta { state })?;
-        let result: GoogleResponse<HmacMeta> = crate::CLIENT
+        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&UpdateMeta { state })
@@ -300,7 +300,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -191,7 +191,7 @@ impl Object {
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_TYPE, mime_type.parse()?);
         headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .post(url)
             .headers(headers)
             .body(file)
@@ -227,7 +227,7 @@ impl Object {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use cloud_storage::Object;
     ///
-    /// let file = crate::CLIENT
+    /// let file = reqwest::Client::new()
     ///     .get("https://my_domain.rs/nice_cat_photo.png")
     ///     .send()
     ///     .await?
@@ -263,7 +263,7 @@ impl Object {
         headers.insert(CONTENT_LENGTH, length.to_string().parse()?);
 
         let body = reqwest::Body::wrap_stream(stream);
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .post(url)
             .headers(headers)
             .body(body)
@@ -389,7 +389,7 @@ impl Object {
                 query.push(("prefix", prefix.to_string()));
             };
 
-            let response = crate::CLIENT
+            let response = reqwest::Client::new()
                 .get(&url)
                 .query(&query)
                 .headers(headers)
@@ -442,7 +442,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -483,7 +483,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(crate::CLIENT
+        Ok(reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -512,7 +512,7 @@ impl Object {
     /// use cloud_storage::Object;
     ///
     /// let stream = Object::download_streamed("my_bucket", "path/to/my/file.png").await?;
-    /// for
+    /// for 
     /// # Ok(())
     /// # }
     /// ```
@@ -528,7 +528,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(crate::CLIENT
+        Ok(reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -557,7 +557,7 @@ impl Object {
             percent_encode(&self.bucket),
             percent_encode(&self.name),
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&self)
@@ -599,7 +599,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -662,7 +662,7 @@ impl Object {
             percent_encode(&bucket),
             percent_encode(&destination_object)
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(req)
@@ -716,7 +716,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(headers)
             .send()
@@ -772,7 +772,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<RewriteResponse> = crate::CLIENT
+        let result: GoogleResponse<RewriteResponse> = reqwest::Client::new()
             .post(&url)
             .headers(headers)
             .send()
@@ -1068,6 +1068,7 @@ mod tests {
         // let data = data.next().await.flat_map(|part| part.into_iter()).collect();
         assert_eq!(data, content);
 
+
         Ok(())
     }
 
@@ -1155,7 +1156,7 @@ mod tests {
         let obj = Object::create(&bucket.name, vec![0, 1], "test-rewrite", "text/plain").await?;
         let obj = obj.rewrite(&bucket.name, "test-rewritten").await?;
         let url = obj.download_url(100)?;
-        let download = crate::CLIENT.head(&url).send().await?;
+        let download = reqwest::Client::new().head(&url).send().await?;
         assert_eq!(download.status().as_u16(), 200);
         Ok(())
     }
@@ -1175,7 +1176,7 @@ mod tests {
             let _obj = Object::create(&bucket.name, vec![0, 1], name, "text/plain").await?;
             let obj = Object::read(&bucket.name, &name).await.unwrap();
             let url = obj.download_url(100)?;
-            let download = crate::CLIENT.head(&url).send().await?;
+            let download = reqwest::Client::new().head(&url).send().await?;
             assert_eq!(download.status().as_u16(), 200);
         }
         Ok(())

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -116,7 +116,7 @@ impl ObjectAccessControl {
         new_object_access_control: &NewObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_object_access_control)
@@ -152,7 +152,7 @@ impl ObjectAccessControl {
     /// control access instead.
     pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
+        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -189,7 +189,7 @@ impl ObjectAccessControl {
             object,
             entity
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -226,7 +226,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let result: GoogleResponse<Self> = crate::CLIENT
+        let result: GoogleResponse<Self> = reqwest::Client::new()
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -264,7 +264,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let response = crate::CLIENT
+        let response = reqwest::Client::new()
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/token.rs
+++ b/src/token.rs
@@ -69,7 +69,7 @@ impl Token {
             ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
             ("assertion", &jwt),
         ];
-        let response: TokenResponse = super::CLIENT
+        let response: TokenResponse = reqwest::Client::new()
             .post("https://www.googleapis.com/oauth2/v4/token")
             .form(&body)
             .send()


### PR DESCRIPTION
Reverts ThouCheese/cloud-storage-rs#19

This causes the tests to fail, and most urgently it causes a deadlock on `resources::object::tests::rewrite`. I'm undoing this merge until we can find a way to make this work properly. Maybe we need to set some keep alive to zero or wrap the `Client` in a mutex (though this would be odd to me since it is Send and Sync).