### PR TITLE
Make create_streamed take length as optional

### DIFF
--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -239,7 +239,7 @@ impl Object {
     pub async fn create_streamed<S>(
         bucket: &str,
         stream: S,
-        length: u64,
+        length: impl Into<Option<u64>>,
         filename: &str,
         mime_type: &str,
     ) -> crate::Result<Self>
@@ -260,7 +260,9 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_TYPE, mime_type.parse()?);
-        headers.insert(CONTENT_LENGTH, length.to_string().parse()?);
+        if let Some(length) = length.into() {
+            headers.insert(CONTENT_LENGTH, length.into());
+        }
 
         let body = reqwest::Body::wrap_stream(stream);
         let response = reqwest::Client::new()
@@ -285,7 +287,7 @@ impl Object {
     pub async fn create_streamed_sync<R: std::io::Read + Send + 'static>(
         bucket: &str,
         mut file: R,
-        length: u64,
+        length: impl Into<Option<u64>>,
         filename: &str,
         mime_type: &str,
     ) -> crate::Result<Self> {


### PR DESCRIPTION
GCS doesn't actually require the `content-length` header, which is nice because a stream's length isn't always known in advance. If a length _is_ provided and less than the actual length, GCS will take just `length` bytes; if `length` is too long, the request will time out.

This is not an api breaking change.