### PR TITLE
Revert/reuse reqwest client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ lazy_static::lazy_static! {
     /// debugging of which service account is currently used. It is of the type
     /// [ServiceAccount](service_account/struct.ServiceAccount.html).
     pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
+
+    static ref CLIENT: reqwest::Client = reqwest::Client::new();
 }
 
 /// A type alias where the error is set to be `cloud_storage::Error`.

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -565,7 +565,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = &crate::SERVICE_ACCOUNT.project_id;
         let query = [("project", project)];
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -609,7 +609,7 @@ impl Bucket {
         let url = format!("{}/b/", crate::BASE_URL);
         let project = &crate::SERVICE_ACCOUNT.project_id;
         let query = [("project", project)];
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&query)
@@ -653,7 +653,7 @@ impl Bucket {
     /// ```
     pub async fn read(name: &str) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, name);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -703,7 +703,7 @@ impl Bucket {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -749,7 +749,7 @@ impl Bucket {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}", crate::BASE_URL, self.name);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -792,7 +792,7 @@ impl Bucket {
     /// ```
     pub async fn get_iam_policy(&self) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+        let result: GoogleResponse<IamPolicy> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -848,7 +848,7 @@ impl Bucket {
     /// ```
     pub async fn set_iam_policy(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
         let url = format!("{}/b/{}/iam", crate::BASE_URL, self.name);
-        let result: GoogleResponse<IamPolicy> = reqwest::Client::new()
+        let result: GoogleResponse<IamPolicy> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(iam)
@@ -891,7 +891,7 @@ impl Bucket {
             ));
         }
         let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, self.name);
-        let result: GoogleResponse<TestIamPermission> = reqwest::Client::new()
+        let result: GoogleResponse<TestIamPermission> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .query(&[("permissions", permission)])

--- a/src/resources/bucket_access_control.rs
+++ b/src/resources/bucket_access_control.rs
@@ -117,7 +117,7 @@ impl BucketAccessControl {
         new_bucket_access_control: &NewBucketAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_bucket_access_control)
@@ -162,7 +162,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -203,7 +203,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -246,7 +246,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -289,7 +289,7 @@ impl BucketAccessControl {
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
         let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/channel.rs
+++ b/src/resources/channel.rs
@@ -1,5 +1,3 @@
-
-
 pub struct Channel {
     pub id: String,
     pub resourceId: String,
@@ -18,10 +16,11 @@ impl Channel {
 
     pub async fn stop_async(&self) -> Result<(), crate::Error> {
         let url = format!("{}/channels/stop", crate::BASE_URL);
-        let response = reqwest::Client::new()
+        let response = create::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
-            .send().await?;
+            .send()
+            .await?;
         if response.status().is_success() {
             Ok(())
         } else {

--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -103,7 +103,7 @@ impl DefaultObjectAccessControl {
         new_acl: &NewDefaultObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_acl)
@@ -150,7 +150,7 @@ impl DefaultObjectAccessControl {
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -206,7 +206,7 @@ impl DefaultObjectAccessControl {
             bucket,
             entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -256,7 +256,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -306,7 +306,7 @@ impl DefaultObjectAccessControl {
             self.bucket,
             self.entity
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -106,7 +106,7 @@ impl HmacKey {
         let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, 0.into());
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .query(&query)
@@ -155,7 +155,7 @@ impl HmacKey {
             crate::BASE_URL,
             crate::SERVICE_ACCOUNT.project_id
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -211,7 +211,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+        let result: GoogleResponse<HmacMeta> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -260,7 +260,7 @@ impl HmacKey {
             access_id
         );
         serde_json::to_string(&UpdateMeta { state })?;
-        let result: GoogleResponse<HmacMeta> = reqwest::Client::new()
+        let result: GoogleResponse<HmacMeta> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&UpdateMeta { state })
@@ -308,7 +308,7 @@ impl HmacKey {
             crate::SERVICE_ACCOUNT.project_id,
             access_id
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/resources/notification.rs
+++ b/src/resources/notification.rs
@@ -31,7 +31,7 @@ pub struct Notification {
     /// The canonical URL of this notification.
     #[serde(rename = "selfLink")]
     self_link: String,
-    /// The kind of item this is. For notifications, this is always `storage#notification`.   
+    /// The kind of item this is. For notifications, this is always `storage#notification`.
     kind: String,
 }
 
@@ -68,8 +68,7 @@ impl Notification {
     /// Creates a notification subscription for a given bucket.
     pub fn create(bucket: &str, new_notification: &NewNotification) -> Result<Self, crate::Error> {
         let url = format!("{}/b/{}/notificationConfigs", crate::BASE_URL, bucket);
-        let client = reqwest::blocking::Client::new();
-        let result: GoogleResponse<Self> = client
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers()?)
             .json(new_notification)
@@ -89,8 +88,7 @@ impl Notification {
             bucket,
             notification
         );
-        let client = reqwest::blocking::Client::new();
-        let result: GoogleResponse<Self> = client
+        let result: GoogleResponse<Self> = crate::CLIENT;
             .get(&url)
             .headers(crate::get_headers()?)
             .send()?
@@ -104,8 +102,7 @@ impl Notification {
     /// Retrieves a list of notification subscriptions for a given bucket.}
     pub fn list(bucket: &str) -> Result<Vec<Self>, crate::Error> {
         let url = format!("{}/v1/b/{}/notificationConfigs", crate::BASE_URL, bucket);
-        let client = reqwest::blocking::Client::new();
-        let result: GoogleResponse<ListResponse<Self>> = client
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers()?)
             .send()?
@@ -124,8 +121,7 @@ impl Notification {
             bucket,
             notification
         );
-        let client = reqwest::blocking::Client::new();
-        let response = client.get(&url).headers(crate::get_headers()?).send()?;
+        let response = crate::CLIENT.get(&url).headers(crate::get_headers()?).send()?;
         if response.status().is_success() {
             Ok(())
         } else {

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -191,7 +191,7 @@ impl Object {
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_TYPE, mime_type.parse()?);
         headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .post(url)
             .headers(headers)
             .body(file)
@@ -227,7 +227,7 @@ impl Object {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use cloud_storage::Object;
     ///
-    /// let file = reqwest::Client::new()
+    /// let file = crate::CLIENT
     ///     .get("https://my_domain.rs/nice_cat_photo.png")
     ///     .send()
     ///     .await?
@@ -265,7 +265,7 @@ impl Object {
         }
 
         let body = reqwest::Body::wrap_stream(stream);
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .post(url)
             .headers(headers)
             .body(body)
@@ -391,7 +391,7 @@ impl Object {
                 query.push(("prefix", prefix.to_string()));
             };
 
-            let response = reqwest::Client::new()
+            let response = crate::CLIENT
                 .get(&url)
                 .query(&query)
                 .headers(headers)
@@ -444,7 +444,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -485,7 +485,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(reqwest::Client::new()
+        Ok(crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -536,7 +536,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        Ok(reqwest::Client::new()
+        Ok(crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -565,7 +565,7 @@ impl Object {
             percent_encode(&self.bucket),
             percent_encode(&self.name),
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(&self)
@@ -607,7 +607,7 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -670,7 +670,7 @@ impl Object {
             percent_encode(&bucket),
             percent_encode(&destination_object)
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(req)
@@ -724,7 +724,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .send()
@@ -780,7 +780,7 @@ impl Object {
         );
         let mut headers = crate::get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<RewriteResponse> = reqwest::Client::new()
+        let result: GoogleResponse<RewriteResponse> = crate::CLIENT
             .post(&url)
             .headers(headers)
             .send()
@@ -844,12 +844,7 @@ impl Object {
         duration: u32,
         opts: crate::DownloadOptions,
     ) -> crate::Result<String> {
-        self.sign(
-            &self.name,
-            duration,
-            "GET",
-            opts.content_disposition,
-        )
+        self.sign(&self.name, duration, "GET", opts.content_disposition)
     }
 
     // /// Creates a [Signed Url](https://cloud.google.com/storage/docs/access-control/signed-urls)
@@ -1258,7 +1253,7 @@ mod tests {
         let obj = Object::create(&bucket.name, vec![0, 1], "test-rewrite", "text/plain").await?;
         let obj = obj.rewrite(&bucket.name, "test-rewritten").await?;
         let url = obj.download_url(100)?;
-        let download = reqwest::Client::new().head(&url).send().await?;
+        let download = crate::CLIENT.head(&url).send().await?;
         assert_eq!(download.status().as_u16(), 200);
         Ok(())
     }
@@ -1278,7 +1273,7 @@ mod tests {
             let _obj = Object::create(&bucket.name, vec![0, 1], name, "text/plain").await?;
             let obj = Object::read(&bucket.name, &name).await.unwrap();
             let url = obj.download_url(100)?;
-            let download = reqwest::Client::new().head(&url).send().await?;
+            let download = crate::CLIENT.head(&url).send().await?;
             assert_eq!(download.status().as_u16(), 200);
         }
         Ok(())

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -116,7 +116,7 @@ impl ObjectAccessControl {
         new_object_access_control: &NewObjectAccessControl,
     ) -> crate::Result<Self> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .post(&url)
             .headers(crate::get_headers().await?)
             .json(new_object_access_control)
@@ -152,7 +152,7 @@ impl ObjectAccessControl {
     /// control access instead.
     pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
         let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<ListResponse<Self>> = reqwest::Client::new()
+        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -189,7 +189,7 @@ impl ObjectAccessControl {
             object,
             entity
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
@@ -226,7 +226,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let result: GoogleResponse<Self> = reqwest::Client::new()
+        let result: GoogleResponse<Self> = crate::CLIENT
             .put(&url)
             .headers(crate::get_headers().await?)
             .json(self)
@@ -264,7 +264,7 @@ impl ObjectAccessControl {
             self.object,
             self.entity,
         );
-        let response = reqwest::Client::new()
+        let response = crate::CLIENT
             .delete(&url)
             .headers(crate::get_headers().await?)
             .send()

--- a/src/token.rs
+++ b/src/token.rs
@@ -69,7 +69,7 @@ impl Token {
             ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
             ("assertion", &jwt),
         ];
-        let response: TokenResponse = reqwest::Client::new()
+        let response: TokenResponse = super::CLIENT
             .post("https://www.googleapis.com/oauth2/v4/token")
             .form(&body)
             .send()


### PR DESCRIPTION
This reverts commit ce4d2b35cf3648d8d99068a02161432e36ec676e.

Related: https://github.com/ThouCheese/cloud-storage-rs/pull/27

```
PR 19 causes the tests to hang, and most urgently it causes a deadlock on resources::object::tests::rewrite. I'm undoing this merge until we can find a way to make this work properly. Maybe we need to set some keep alive to zero or wrap the Client in a mutex (though this would be odd to me since it is Send and Sync).
```

I am willing to find a problem and proceed with reuse of Reqwest client 