### PR TITLE
service_account: add GOOGLE_STORAGE_CREDENTIALS env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ println!("{}", object.download_url(1000)); // download link for 1000 seconds
 object.delete().await?;
 ```
 
-Authorization can be granted using the `SERVICE_ACCOUNT` environment variable, which should contain path to the `service-account-*******.json` file that contains the Google credentials. The service account requires the permission `devstorage.full_control`. This is not strictly necessary, so if you need this fixed, let me know! 
+Authorization can be granted using either `GOOGLE_STORAGE_CREDENTIALS` or the `SERVICE_ACCOUNT` environment variable, which should contain path to the `service-account-*******.json` file that contains the Google credentials. The service account requires the permission `devstorage.full_control`. This is not strictly necessary, so if you need this fixed, let me know!
 
 The service account should also have the roles `Service Account Token Creator` (for generating access tokens) and `Storage Object Admin` (for generating sign urls to download the files).
 

--- a/src/resources/service_account.rs
+++ b/src/resources/service_account.rs
@@ -27,10 +27,11 @@ pub struct ServiceAccount {
 impl ServiceAccount {
     pub(crate) fn get() -> Self {
         dotenv::dotenv().ok();
-        let path = std::env::var("SERVICE_ACCOUNT")
+        let path = std::env::var("GOOGLE_STORAGE_CREDENTIALS")
+            .or_else(|_| std::env::var("SERVICE_ACCOUNT"))
             .or_else(|_| std::env::var("GOOGLE_APPLICATION_CREDENTIALS"))
             .expect(
-                "SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS environment parameter required",
+                "GOOGLE_STORAGE_CREDENTIALS or SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS environment parameter required",
             );
         let file = std::fs::read_to_string(path).expect("SERVICE_ACCOUNT file not found");
         let account: Self = serde_json::from_str(&file).expect("serivce account file not valid");


### PR DESCRIPTION
Change-Id: I87b2c11181a90a6323b7592415e107d216fed364

This adds support for `GOOGLE_STORAGE_CREDENTIALS` environment variable, it targets storage-specific credentials 