### PR TITLE
Accept service account credentials as JSON-containing env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ println!("{}", object.download_url(1000)); // download link for 1000 seconds
 object.delete().await?;
 ```
 
-Authorization can be granted using the `SERVICE_ACCOUNT` environment variable, which should contain path to the `service-account-*******.json` file that contains the Google credentials. The service account requires the permission `devstorage.full_control`. This is not strictly necessary, so if you need this fixed, let me know! 
+Authorization can be granted using the `SERVICE_ACCOUNT` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable, which should contain path to the `service-account-*******.json` file that contains the Google credentials. Alternatively, the service account credentials can be provided as JSON directly through the `SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS_JSON` environment variable, which is useful when providing secrets in CI or k8s.
 
+The service account requires the permission `devstorage.full_control`. This is not strictly necessary, so if you need this fixed, let me know!  
 The service account should also have the roles `Service Account Token Creator` (for generating access tokens) and `Storage Object Admin` (for generating sign urls to download the files).
 
 ### Sync

--- a/src/resources/service_account.rs
+++ b/src/resources/service_account.rs
@@ -27,16 +27,20 @@ pub struct ServiceAccount {
 impl ServiceAccount {
     pub(crate) fn get() -> Self {
         dotenv::dotenv().ok();
-        let path = std::env::var("SERVICE_ACCOUNT")
+        let credentials_json = std::env::var("SERVICE_ACCOUNT")
             .or_else(|_| std::env::var("GOOGLE_APPLICATION_CREDENTIALS"))
+            .map(|path| std::fs::read_to_string(path).expect("SERVICE_ACCOUNT file not found"))
+            .or_else(|_| std::env::var("SERVICE_ACCOUNT_JSON"))
+            .or_else(|_| std::env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON"))
             .expect(
-                "SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS environment parameter required",
+                "SERVICE_ACCOUNT(_JSON) or GOOGLE_APPLICATION_CREDENTIALS(_JSON) environment parameter required",
             );
-        let file = std::fs::read_to_string(path).expect("SERVICE_ACCOUNT file not found");
-        let account: Self = serde_json::from_str(&file).expect("serivce account file not valid");
-        if account.r#type != "service_account" {
-            panic!("`type` paramter of `SERVICE_ACCOUNT` variable is not 'service_account'");
-        }
+        let account: Self =
+            serde_json::from_str(&credentials_json).expect("SERVICE_ACCOUNT file not valid");
+        assert_eq!(
+            account.r#type, "service_account",
+            "`type` parameter of `SERVICE_ACCOUNT` variable is not 'service_account'"
+        );
         account
     }
 }


### PR DESCRIPTION
This is useful when using secret managers like GitHub Actions that provide secrets as environment variables. The workaround is having an annoying method like

```rust
pub async fn load_gcp_creds(json_creds: &str) -> Result<()> {
      let mut creds_tempfile =
          tempfile::NamedTempFile::new().expect("couldn't open creds tempfile");
      creds_tempfile
          .write_all(json_creds.as_bytes())
          .expect("couldn't write creds json");
      std::env::set_var(ENV_GCP_CREDS, creds_json);
      cloud_storage::Object::list_prefix(&bucket, &prefix)
          .await?
          .try_for_each_concurrent(None, |_| async { Ok(()) })
          .await?;
      //^ This exists to force loading `cloud_storage::SERVICE_ACCOUNT` into memory
      // so that the credentials file can be removed.
      Ok(())
}
```

I think that this is a fairly common operation given the ubiquity of secret managers, so the feature might be useful to others (hence the PR).
