### PR TITLE
Support listing with a delimiter and getting back prefixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::{
     error::*,
     resources::{
         bucket::{Bucket, NewBucket},
-        object::Object,
+        object::{ListRequest, Object},
         *,
     },
 };

--- a/src/resources/common.rs
+++ b/src/resources/common.rs
@@ -63,8 +63,6 @@ pub enum Role {
 pub(crate) struct ListResponse<T> {
     #[serde(default = "Vec::new")]
     pub items: Vec<T>,
-    #[serde(default = "Vec::new")]
-    pub prefixes: Vec<String>,
     pub next_page_token: Option<String>,
 }
 

--- a/src/resources/common.rs
+++ b/src/resources/common.rs
@@ -63,6 +63,8 @@ pub enum Role {
 pub(crate) struct ListResponse<T> {
     #[serde(default = "Vec::new")]
     pub items: Vec<T>,
+    #[serde(default = "Vec::new")]
+    pub prefixes: Vec<String>,
     pub next_page_token: Option<String>,
 }
 


### PR DESCRIPTION
Hi! Over in https://github.com/influxdata/influxdb_iox, we need to be able to specify a `delimiter` to the `list` request and get back the prefixes along with the objects in that case.

This PR is the bare minimum that we would need... while working on this, I noticed there are many more query parameters that can be sent to the list API that aren't currently supported. Would you rather have a more comprehensive solution instead? Such as a public `list` function that takes a struct with all of the optional query parameters as fields with `Option` values?

Looking forward to your feedback, thank you!