### PR TITLE
Make docs say synchronous consistently

### DIFF
--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -314,7 +314,7 @@ impl DefaultObjectAccessControl {
         }
     }
 
-    /// The async equivalent of `DefautObjectAccessControl::delete`.
+    /// The synchronous equivalent of `DefautObjectAccessControl::delete`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -175,7 +175,7 @@ impl HmacKey {
         }
     }
 
-    /// The async equivalent of `HmacKey::list`.
+    /// The synchronous equivalent of `HmacKey::list`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -278,7 +278,7 @@ impl Object {
         }
     }
 
-    /// The async equivalent of `Object::create_streamed`.
+    /// The synchronous equivalent of `Object::create_streamed`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -318,7 +318,7 @@ impl Object {
         Self::list_from(bucket, None).await
     }
 
-    /// The async equivalent of `Object::list`.
+    /// The synchronous equivalent of `Object::list`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -349,7 +349,7 @@ impl Object {
         Self::list_from(bucket, Some(prefix)).await
     }
 
-    /// The async equivalent of `Object::list_prefix`.
+    /// The synchronous equivalent of `Object::list_prefix`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -880,7 +880,7 @@ impl Object {
     ///
     /// let obj1 = Object::read("my_bucket", "file1").await?;
     /// let mut custom_metadata = HashMap::new();
-    /// custom_metadata.insert(String::from("field"), String::from("value"));    
+    /// custom_metadata.insert(String::from("field"), String::from("value"));
     /// let (url, headers) = obj1.upload_url_with(50, custom_metadata)?;
     /// // url is now a url to which an unauthenticated user can make a PUT request to upload a file
     /// // for 50 seconds. Note that the user must also include the returned headers in the PUT request

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -130,7 +130,7 @@ impl ObjectAccessControl {
         }
     }
 
-    /// The sync equivalent of `ObjectAccessControl::create`.
+    /// The synchronous equivalent of `ObjectAccessControl::create`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -164,7 +164,7 @@ impl ObjectAccessControl {
         }
     }
 
-    /// The sync equivalent of `ObjectAccessControl::list`.
+    /// The synchronous equivalent of `ObjectAccessControl::list`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -200,7 +200,7 @@ impl ObjectAccessControl {
         }
     }
 
-    /// The sync equivalent of `ObjectAccessControl::read`.
+    /// The synchronous equivalent of `ObjectAccessControl::read`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -237,7 +237,7 @@ impl ObjectAccessControl {
         }
     }
 
-    /// The sync equivalent of `ObjectAccessControl::update`.
+    /// The synchronous equivalent of `ObjectAccessControl::update`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
@@ -272,7 +272,7 @@ impl ObjectAccessControl {
         }
     }
 
-    /// The sync equivalent of `ObjectAccessControl::delete`.
+    /// The synchronous equivalent of `ObjectAccessControl::delete`.
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.


### PR DESCRIPTION
Just a little thing I noticed while working on #57 - some of these places say "async" when they should say "synchronous", and some places correctly say "sync" but most places spelled it out "synchronous" so I decided to make them all consistent :)