### PR TITLE
Include HashMap in a doctest that needs it

### DIFF
--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -877,10 +877,11 @@ impl Object {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use cloud_storage::object::{Object, ComposeRequest};
+    /// use std::collections::HashMap;
     ///
     /// let obj1 = Object::read("my_bucket", "file1").await?;
     /// let mut custom_metadata = HashMap::new();
-    /// custom_metadata.insert(String::from("field"), String::from("value"));    
+    /// custom_metadata.insert(String::from("field"), String::from("value"));
     /// let (url, headers) = obj1.upload_url_with(50, custom_metadata)?;
     /// // url is now a url to which an unauthenticated user can make a PUT request to upload a file
     /// // for 50 seconds. Note that the user must also include the returned headers in the PUT request


### PR DESCRIPTION
It looks like I don't have permissions to the SERVICE_ACCOUNT for CI, which I totally understand.

The tests for #57 are passing for me locally except for this doc test, which uses `HashMap` but doesn't import it.