### PR TITLE
fix: alloc feature for hex, fixes release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static =      { version = "1",    default-features = false }
 dotenv =           { version = "0.15", default-features = false }
 openssl =          { version = "0.10", default-features = false }
 chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
-hex =              { version = "0.4",  default-features = false }
+hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
 tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
 futures =          { version = "0.3",  default_features = false, features = ["alloc"] }
 bytes =            { version = "1.0",  default_features = false }


### PR DESCRIPTION
0.4.3 hex version introduced alloc feature without which `cargo build --release` of cloud-storage-rs [fails](https://github.com/onsails/cloud-storage-sync/runs/2022939454).