### PR TITLE
Fixes `encode` not found in `hex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static =      { version = "1",    default-features = false }
 dotenv =           { version = "0.15", default-features = false }
 openssl =          { version = "0.10", default-features = false }
 chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
-hex =              { version = "0.4",  default-features = false }
+hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
 tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
 futures =          { version = "0.3",  default_features = false, features = ["alloc"] }
 bytes =            { version = "1.0",  default_features = false }


### PR DESCRIPTION
```
error[E0425]: cannot find function `encode` in crate `hex`
    --> src/resources/object.rs:1016:29
     |
1016 |         let hex_hash = hex::encode(hash);
     |                             ^^^^^^ not found in `hex`
     |
help: consider importing one of these items
```