### PR TITLE
Create a non-global Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["api-bindings", "web-programming"]
 [features]
 default = ["native-tls"]
 
+global-client = []
 sync = ["reqwest/blocking"]
 native-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
@@ -37,4 +38,4 @@ futures =          { version = "0.3",  default_features = false, features = ["al
 bytes =            { version = "1.0",  default_features = false }
 
 [package.metadata.docs.rs]
-features = ["sync"]
+features = ["global-client", "sync"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,86 @@
+//! Clients for Google Cloud Storage endpoints.
+
+use tokio::sync::Mutex;
+
+use crate::token::Token;
+
+mod bucket;
+mod bucket_access_control;
+mod default_object_access_control;
+mod hmac_key;
+mod object;
+mod object_access_control;
+
+pub use bucket::BucketClient;
+pub use bucket_access_control::BucketAccessControlClient;
+pub use default_object_access_control::DefaultObjectAccessControlClient;
+pub use hmac_key::HmacKeyClient;
+pub use object::ObjectClient;
+pub use object_access_control::ObjectAccessControlClient;
+
+/// The primary entrypoint to perform operations with Google Cloud Storage.
+pub struct Client {
+    client: reqwest::Client,
+
+    /// Static `Token` struct that caches
+    token_cache: Mutex<Token>,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self {
+            client: Default::default(),
+            token_cache: Mutex::new(Token::new(
+                "https://www.googleapis.com/auth/devstorage.full_control",
+            )),
+        }
+    }
+}
+
+impl Client {
+    /// Constructs a client
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Operations on [`Bucket`](crate::bucket::Bucket)s.
+    pub fn bucket(&self) -> BucketClient<'_> {
+        BucketClient(self)
+    }
+
+    /// Operations on [`BucketAccessControl`](crate::bucket_access_control::BucketAccessControl)s.
+    pub fn bucket_access_control(&self) -> BucketAccessControlClient<'_> {
+        BucketAccessControlClient(self)
+    }
+
+    /// Operations on [`DefaultObjectAccessControl`](crate::default_object_access_control::DefaultObjectAccessControl)s.
+    pub fn default_object_access_control(&self) -> DefaultObjectAccessControlClient<'_> {
+        DefaultObjectAccessControlClient(self)
+    }
+
+    /// Operations on [`HmacKey`](crate::hmac_key::HmacKey)s.
+    pub fn hmac_key(&self) -> HmacKeyClient<'_> {
+        HmacKeyClient(self)
+    }
+
+    /// Operations on [`Object`](crate::object::Object)s.
+    pub fn object(&self) -> ObjectClient<'_> {
+        ObjectClient(self)
+    }
+
+    /// Operations on [`ObjectAccessControl`](crate::object_access_control::ObjectAccessControl)s.
+    pub fn object_access_control(&self) -> ObjectAccessControlClient<'_> {
+        ObjectAccessControlClient(self)
+    }
+
+    async fn get_headers(&self) -> crate::Result<reqwest::header::HeaderMap> {
+        let mut result = reqwest::header::HeaderMap::new();
+        let mut guard = self.token_cache.lock().await;
+        let token = guard.get(&self.client).await?;
+        result.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", token).parse().unwrap(),
+        );
+        Ok(result)
+    }
+}

--- a/src/client/bucket.rs
+++ b/src/client/bucket.rs
@@ -1,0 +1,351 @@
+use crate::{
+    bucket::{IamPolicy, TestIamPermission},
+    error::GoogleResponse,
+    resources::common::ListResponse,
+    Bucket, NewBucket,
+};
+
+/// Operations on [`Bucket`]()s.
+pub struct BucketClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketClient<'a> {
+    /// Creates a new `Bucket`. There are many options that you can provide for creating a new
+    /// bucket, so the `NewBucket` resource contains all of them. Note that `NewBucket` implements
+    /// `Default`, so you don't have to specify the fields you're not using. And error is returned
+    /// if that bucket name is already taken.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket::{Bucket, NewBucket};
+    /// use cloud_storage::bucket::{Location, MultiRegion};
+    ///
+    /// let client = Client::default();
+    /// let new_bucket = NewBucket {
+    ///    name: "cloud-storage-rs-doc-1".to_string(), // this is the only mandatory field
+    ///    location: Location::Multi(MultiRegion::Eu),
+    ///    ..Default::default()
+    /// };
+    /// let bucket = client.bucket().create(&new_bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(&self, new_bucket: &NewBucket) -> crate::Result<Bucket> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&query)
+            .json(new_bucket)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns all `Bucket`s within this project.
+    ///
+    /// ### Note
+    /// When using incorrect permissions, this function fails silently and returns an empty list.
+    ///
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// let buckets = client.bucket().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> crate::Result<Vec<Bucket>> {
+        let url = format!("{}/b/", crate::BASE_URL);
+        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let query = [("project", project)];
+        let result: GoogleResponse<ListResponse<Bucket>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns a single `Bucket` by its name. If the Bucket does not exist, an error is returned.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-2".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-2").await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, name: &str) -> crate::Result<Bucket> {
+        let url = format!("{}/b/{}", crate::BASE_URL, name);
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update an existing `Bucket`. If you declare you bucket as mutable, you can edit its fields.
+    /// You can then flush your changes to Google Cloud Storage using this method.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket::{Bucket, RetentionPolicy};
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-3".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3").await?;
+    /// bucket.retention_policy = Some(RetentionPolicy {
+    ///     retention_period: 50,
+    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     is_locked: Some(false),
+    /// });
+    /// client.bucket().update(&bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self, bucket: &Bucket) -> crate::Result<Bucket> {
+        let url = format!("{}/b/{}", crate::BASE_URL, bucket.name);
+        let result: GoogleResponse<Bucket> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(bucket)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Delete an existing `Bucket`. This permanently removes a bucket from Google Cloud Storage.
+    /// An error is returned when you don't have sufficient permissions, or when the
+    /// `retention_policy` prevents you from deleting your Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "unnecessary-bucket".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("unnecessary-bucket").await?;
+    /// client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket: Bucket) -> crate::Result<()> {
+        let url = format!("{}/b/{}", crate::BASE_URL, bucket.name);
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// Returns the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-4".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-4").await?;
+    /// let policy = client.bucket().get_iam_policy(&bucket).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_iam_policy(&self, bucket: &Bucket) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, bucket.name);
+        let result: GoogleResponse<IamPolicy> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    /// use cloud_storage::bucket::{IamPolicy, Binding, IamRole, StandardIamRole, Entity};
+    ///
+    /// let client = Client::default();
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-5".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket).await?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-5").await?;
+    /// let iam_policy = IamPolicy {
+    ///     version: 1,
+    ///     bindings: vec![
+    ///         Binding {
+    ///             role: IamRole::Standard(StandardIamRole::ObjectViewer),
+    ///             members: vec!["allUsers".to_string()],
+    ///             condition: None,
+    ///         }
+    ///     ],
+    ///     ..Default::default()
+    /// };
+    /// let policy = client.bucket().set_iam_policy(&bucket, &iam_policy).await?;
+    /// # client.bucket().delete(bucket).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_iam_policy(
+        &self,
+        bucket: &Bucket,
+        iam: &IamPolicy,
+    ) -> crate::Result<IamPolicy> {
+        let url = format!("{}/b/{}/iam", crate::BASE_URL, bucket.name);
+        let result: GoogleResponse<IamPolicy> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(iam)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Checks whether the user provided in the service account has this permission.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::default();
+    /// let bucket = client.bucket().read("my-bucket").await?;
+    /// client.bucket().test_iam_permission(&bucket, "storage.buckets.get").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn test_iam_permission(
+        &self,
+        bucket: &Bucket,
+        permission: &str,
+    ) -> crate::Result<TestIamPermission> {
+        if permission == "storage.buckets.list" || permission == "storage.buckets.create" {
+            return Err(crate::Error::new(
+                "tested permission must not be `storage.buckets.list` or `storage.buckets.create`",
+            ));
+        }
+        let url = format!("{}/b/{}/iam/testPermissions", crate::BASE_URL, bucket.name);
+        let result: GoogleResponse<TestIamPermission> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .query(&[("permissions", permission)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+}

--- a/src/client/bucket_access_control.rs
+++ b/src/client/bucket_access_control.rs
@@ -1,0 +1,212 @@
+use crate::{
+    bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl},
+    error::GoogleResponse,
+    resources::common::ListResponse,
+};
+
+/// Operations on [`BucketAccessControl`](BucketAccessControl)s.
+pub struct BucketAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketAccessControlClient<'a> {
+    /// Create a new `BucketAccessControl` using the provided `NewBucketAccessControl`, related to
+    /// the `Bucket` provided by the `bucket_name` argument.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+    /// use cloud_storage::bucket_access_control::{Role, Entity};
+    ///
+    /// let client = Client::default();
+    /// let new_bucket_access_control = NewBucketAccessControl {
+    ///     entity: Entity::AllUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// client.bucket_access_control().create("mybucket", &new_bucket_access_control).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_bucket_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns all `BucketAccessControl`s related to this bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::BucketAccessControl;
+    ///
+    /// let client = Client::default();
+    /// let acls = client.bucket_access_control().list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self, bucket: &str) -> crate::Result<Vec<BucketAccessControl>> {
+        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<ListResponse<BucketAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<BucketAccessControl> {
+        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update this `BucketAccessControl`.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut acl = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.bucket_access_control().update(&acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        bucket_access_control: &BucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        let url = format!(
+            "{}/b/{}/acl/{}",
+            crate::BASE_URL,
+            bucket_access_control.bucket,
+            bucket_access_control.entity
+        );
+        let result: GoogleResponse<BucketAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(bucket_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// client.bucket_access_control().delete(controls).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket_access_control: BucketAccessControl) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/acl/{}",
+            crate::BASE_URL,
+            bucket_access_control.bucket,
+            bucket_access_control.entity
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/src/client/default_object_access_control.rs
+++ b/src/client/default_object_access_control.rs
@@ -1,0 +1,241 @@
+use crate::{
+    bucket_access_control::Entity,
+    default_object_access_control::{DefaultObjectAccessControl, NewDefaultObjectAccessControl},
+    error::GoogleResponse,
+    resources::common::ListResponse,
+};
+
+/// Operations on [`DefaultObjectAccessControl`](DefaultObjectAccessControl)s.
+pub struct DefaultObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> DefaultObjectAccessControlClient<'a> {
+    /// Create a new `DefaultObjectAccessControl` entry on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{
+    ///     DefaultObjectAccessControl, NewDefaultObjectAccessControl, Role, Entity,
+    /// };
+    ///
+    /// let client = Client::default();
+    /// let new_acl = NewDefaultObjectAccessControl {
+    ///     entity: Entity::AllAuthenticatedUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// let default_acl = client.default_object_access_control().create("mybucket", &new_acl).await?;
+    /// # client.default_object_access_control().delete(default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_acl)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves default object ACL entries on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::DefaultObjectAccessControl;
+    ///
+    /// let client = Client::default();
+    /// let default_acls = client.default_object_access_control().list("mybucket").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self, bucket: &str) -> crate::Result<Vec<DefaultObjectAccessControl>> {
+        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
+        let result: GoogleResponse<ListResponse<DefaultObjectAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s
+                .items
+                .into_iter()
+                .map(|item| DefaultObjectAccessControl {
+                    bucket: bucket.to_string(),
+                    ..item
+                })
+                .collect()),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Read a single `DefaultObjectAccessControl`.
+    /// The `bucket` argument is the name of the bucket whose `DefaultObjectAccessControl` is to be
+    /// read, and the `entity` argument is the entity holding the permission. Options are
+    /// Can be "user-`userId`", "user-`email_address`", "group-`group_id`", "group-`email_address`",
+    /// "allUsers", or "allAuthenticatedUsers".
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let default_acl = client.default_object_access_control().read("mybucket", &Entity::AllUsers).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(
+        &self,
+        bucket: &str,
+        entity: &Entity,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            bucket,
+            entity
+        );
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Update the current `DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers).await?;
+    /// default_acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.default_object_access_control().update(&default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(
+        &self,
+        default_object_access_control: &DefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            default_object_access_control.bucket,
+            default_object_access_control.entity
+        );
+        let result: GoogleResponse<DefaultObjectAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(default_object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(mut s) => {
+                s.bucket = default_object_access_control.bucket.to_string();
+                Ok(s)
+            }
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Delete this 'DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::default();
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers).await?;
+    /// client.default_object_access_control().delete(default_acl).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(
+        &self,
+        default_object_access_control: DefaultObjectAccessControl,
+    ) -> Result<(), crate::Error> {
+        let url = format!(
+            "{}/b/{}/defaultObjectAcl/{}",
+            crate::BASE_URL,
+            default_object_access_control.bucket,
+            default_object_access_control.entity
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/src/client/hmac_key.rs
+++ b/src/client/hmac_key.rs
@@ -1,0 +1,235 @@
+use crate::{
+    error::GoogleResponse,
+    hmac_key::{HmacKey, HmacMeta, HmacState},
+};
+
+/// Operations on [`HmacKey`](HmacKey)s.
+pub struct HmacKeyClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> HmacKeyClient<'a> {
+    /// Creates a new HMAC key for the specified service account.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.create` permission for the project in
+    /// which the key will be created.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let hmac_key = client.hmac_key().create().await?;
+    /// # use cloud_storage::hmac_key::HmacState;
+    /// # client.hmac_key().update(&hmac_key.metadata.access_id, HmacState::Inactive).await?;
+    /// # client.hmac_key().delete(&hmac_key.metadata.access_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(&self) -> crate::Result<HmacKey> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, 0.into());
+        let result: GoogleResponse<HmacKey> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .query(&query)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves a list of HMAC keys matching the criteria. Since the HmacKey is secret, this does
+    /// not return a `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but
+    /// with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.list` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let all_hmac_keys = client.hmac_key().list().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(&self) -> crate::Result<Vec<HmacMeta>> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id
+        );
+        let response = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .text()
+            .await?;
+        let result: Result<GoogleResponse<crate::hmac_key::ListResponse>, _> =
+            serde_json::from_str(&response);
+
+        // This function rquires more complicated error handling because when there is only one
+        // entry, Google will return the response `{ "kind": "storage#hmacKeysMetadata" }` instead
+        // of a list with one element. This breaks the parser.
+        match result {
+            Ok(parsed) => match parsed {
+                GoogleResponse::Success(s) => Ok(s.items),
+                GoogleResponse::Error(e) => Err(e.into()),
+            },
+            Err(_) => Ok(vec![]),
+        }
+    }
+
+    /// Retrieves an HMAC key's metadata. Since the HmacKey is secret, this does not return a
+    /// `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but with the secret
+    /// data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.get` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().read("some identifier").await?;
+    /// # Ok(())
+    /// # }
+    pub async fn read(&self, access_id: &str) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let result: GoogleResponse<HmacMeta> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.
+    /// Since the HmacKey is secret, this does not return a `HmacKey`, but a `HmacMeta`. This is a
+    /// redacted version of a `HmacKey`, but with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.update` permission for the project in
+    /// which the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().update("your key", HmacState::Active).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn update(&self, access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        serde_json::to_string(&crate::hmac_key::UpdateMeta { state })?;
+        let result: GoogleResponse<HmacMeta> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(&crate::hmac_key::UpdateMeta { state })
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Deletes an HMAC key. Note that a key must be set to `Inactive` first.
+    ///
+    /// The authenticated user must have storage.hmacKeys.delete permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::default();
+    /// let key = client.hmac_key().update("your key", HmacState::Inactive).await?; // this is required.
+    /// client.hmac_key().delete(&key.access_id).await?;
+    /// # Ok(())
+    /// # }
+    pub async fn delete(&self, access_id: &str) -> crate::Result<()> {
+        let url = format!(
+            "{}/projects/{}/hmacKeys/{}",
+            crate::BASE_URL,
+            crate::SERVICE_ACCOUNT.project_id,
+            access_id
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -1,0 +1,582 @@
+use futures::{stream, Stream, TryStream};
+use reqwest::StatusCode;
+
+use crate::{
+    error::GoogleResponse,
+    object::{percent_encode, ComposeRequest, ObjectList, RewriteResponse, SizedByteStream},
+    ListRequest, Object,
+};
+
+/// Operations on [`Object`](Object)s.
+pub struct ObjectClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectClient<'a> {
+    /// Create a new object.
+    /// Upload a file as that is loaded in memory to google cloud storage, where it will be
+    /// interpreted according to the mime type you specified.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::default();
+    /// client.object().create("cat-photos", file, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object> {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        // has its own url for some reason
+        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
+        let response = self
+            .0
+            .client
+            .post(url)
+            .headers(headers)
+            .body(file)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(crate::Error::new(&response.text().await?))
+        }
+    }
+
+    /// Create a new object. This works in the same way as `ObjectClient::create`, except it does not need
+    /// to load the entire file in ram.
+    /// ## Example
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let file = reqwest::Client::new()
+    ///     .get("https://my_domain.rs/nice_cat_photo.png")
+    ///     .send()
+    ///     .await?
+    ///     .bytes_stream();
+    /// client.object().create_streamed("cat-photos", file, 10, "recently read cat.png", "image/png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_streamed<S>(
+        &self,
+        bucket: &str,
+        stream: S,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object>
+    where
+        S: TryStream + Send + Sync + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        bytes::Bytes: From<S::Ok>,
+    {
+        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+
+        // has its own url for some reason
+        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
+        let url = &format!(
+            "{}/{}/o?uploadType=media&name={}",
+            BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&filename),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_TYPE, mime_type.parse()?);
+        if let Some(length) = length.into() {
+            headers.insert(CONTENT_LENGTH, length.into());
+        }
+
+        let body = reqwest::Body::wrap_stream(stream);
+        let response = self
+            .0
+            .client
+            .post(url)
+            .headers(headers)
+            .body(body)
+            .send()
+            .await?;
+        if response.status() == 200 {
+            Ok(serde_json::from_str(&response.text().await?)?)
+        } else {
+            Err(crate::Error::new(&response.text().await?))
+        }
+    }
+
+    /// Obtain a list of objects within this Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::{Object, ListRequest};
+    ///
+    /// let client = Client::default();
+    /// let all_objects = client.object().list("my_bucket", ListRequest::default()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list(
+        &self,
+        bucket: &'a str,
+        list_request: ListRequest,
+    ) -> crate::Result<impl Stream<Item = crate::Result<ObjectList>> + 'a> {
+        enum ListState {
+            Start(ListRequest),
+            HasMore(ListRequest),
+            Done,
+        }
+        use ListState::*;
+        impl ListState {
+            fn into_has_more(self) -> Option<ListState> {
+                match self {
+                    Start(req) | HasMore(req) => Some(HasMore(req)),
+                    Done => None,
+                }
+            }
+
+            fn req_mut(&mut self) -> Option<&mut ListRequest> {
+                match self {
+                    Start(ref mut req) | HasMore(ref mut req) => Some(req),
+                    Done => None,
+                }
+            }
+        }
+
+        let client = self.0;
+
+        Ok(stream::unfold(
+            ListState::Start(list_request),
+            move |mut state| async move {
+                let url = format!("{}/b/{}/o", crate::BASE_URL, percent_encode(bucket));
+                let headers = match client.get_headers().await {
+                    Ok(h) => h,
+                    Err(e) => return Some((Err(e), state)),
+                };
+                let req = state.req_mut()?;
+                if req.max_results == Some(0) {
+                    return None;
+                }
+
+                let response = client
+                    .client
+                    .get(&url)
+                    .query(req)
+                    .headers(headers)
+                    .send()
+                    .await;
+
+                let response = match response {
+                    Ok(r) if r.status() == 200 => r,
+                    Ok(r) => {
+                        let e = match r.json::<crate::error::GoogleErrorResponse>().await {
+                            Ok(err_res) => err_res.into(),
+                            Err(serde_err) => serde_err.into(),
+                        };
+                        return Some((Err(e), state));
+                    }
+                    Err(e) => return Some((Err(e.into()), state)),
+                };
+
+                let result: GoogleResponse<ObjectList> = match response.json().await {
+                    Ok(json) => json,
+                    Err(e) => return Some((Err(e.into()), state)),
+                };
+
+                let response_body = match result {
+                    GoogleResponse::Success(success) => success,
+                    GoogleResponse::Error(e) => return Some((Err(e.into()), state)),
+                };
+
+                let next_state = if let Some(ref page_token) = response_body.next_page_token {
+                    req.page_token = Some(page_token.clone());
+                    req.max_results = req
+                        .max_results
+                        .map(|rem| rem.saturating_sub(response_body.items.len()));
+                    state.into_has_more()?
+                } else {
+                    Done
+                };
+
+                Some((Ok(response_body), next_state))
+            },
+        ))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let object = client.object().read("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn read(&self, bucket: &str, file_name: &str) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let bytes = client.object().download("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download(&self, bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let resp = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            Err(crate::Error::Other(resp.text().await?))
+        } else {
+            Ok(resp.error_for_status()?.bytes().await?.to_vec())
+        }
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket, without
+    /// allocating the whole file into a vector.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    /// use futures::StreamExt;
+    /// use std::fs::File;
+    /// use std::io::{BufWriter, Write};
+    ///
+    /// let client = Client::default();
+    /// let mut stream = client.object().download_streamed("my_bucket", "path/to/my/file.png").await?;
+    /// let mut file = BufWriter::new(File::create("file.png").unwrap());
+    /// while let Some(byte) = stream.next().await {
+    ///     file.write_all(&[byte.unwrap()]).unwrap();
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download_streamed(
+        &self,
+        bucket: &str,
+        file_name: &str,
+    ) -> crate::Result<impl Stream<Item = crate::Result<u8>> + Unpin> {
+        use futures::{StreamExt, TryStreamExt};
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let response = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .error_for_status()?;
+        let size = response.content_length();
+        let bytes = response
+            .bytes_stream()
+            .map(|chunk| chunk.map(|c| futures::stream::iter(c.into_iter().map(Ok))))
+            .try_flatten();
+        Ok(SizedByteStream::new(bytes, size))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// let mut object = client.object().read("my_bucket", "path/to/my/file.png").await?;
+    /// object.content_type = Some("application/xml".to_string());
+    /// client.object().update(&object).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn update(&self, object: &Object) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(&object.bucket),
+            percent_encode(&object.name),
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(&object)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Deletes a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::default();
+    /// client.object().delete("my_bucket", "path/to/my/file.png").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete(&self, bucket: &str, file_name: &str) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/o/{}",
+            crate::BASE_URL,
+            percent_encode(bucket),
+            percent_encode(file_name),
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest, SourceObject};
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().read("my_bucket", "file2").await?;
+    /// let compose_request = ComposeRequest {
+    ///     kind: "storage#composeRequest".to_string(),
+    ///     source_objects: vec![
+    ///         SourceObject {
+    ///             name: obj1.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///         SourceObject {
+    ///             name: obj2.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///     ],
+    ///     destination: None,
+    /// };
+    /// let obj3 = client.object().compose("my_bucket", &compose_request, "test-concatted-file").await?;
+    /// // obj3 is now a file with the content of obj1 and obj2 concatted together.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn compose(
+        &self,
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Object> {
+        let url = format!(
+            "{}/b/{}/o/{}/compose",
+            crate::BASE_URL,
+            percent_encode(&bucket),
+            percent_encode(&destination_object)
+        );
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(req)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Copy this object to the target bucket and path
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().copy(&obj1, "my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn copy(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/copyTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&object.bucket),
+            sObject = percent_encode(&object.name),
+            dBucket = percent_encode(&destination_bucket),
+            dObject = percent_encode(&path),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<Object> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Moves a file from the current location to the target bucket and path.
+    ///
+    /// ## Limitations
+    /// This function does not yet support rewriting objects to another
+    /// * Geographical Location,
+    /// * Encryption,
+    /// * Storage class.
+    /// These limitations mean that for now, the rewrite and the copy methods do the same thing.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Client;
+    /// use cloud_storage::object::Object;
+    ///
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
+    /// let obj2 = client.object().rewrite(&obj1, "my_other_bucket", "file2").await?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn rewrite(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        use reqwest::header::CONTENT_LENGTH;
+
+        let url = format!(
+            "{base}/b/{sBucket}/o/{sObject}/rewriteTo/b/{dBucket}/o/{dObject}",
+            base = crate::BASE_URL,
+            sBucket = percent_encode(&object.bucket),
+            sObject = percent_encode(&object.name),
+            dBucket = percent_encode(destination_bucket),
+            dObject = percent_encode(path),
+        );
+        let mut headers = self.0.get_headers().await?;
+        headers.insert(CONTENT_LENGTH, "0".parse()?);
+        let result: GoogleResponse<RewriteResponse> = self
+            .0
+            .client
+            .post(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.resource),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+}

--- a/src/client/object_access_control.rs
+++ b/src/client/object_access_control.rs
@@ -1,0 +1,162 @@
+use crate::{
+    bucket_access_control::Entity,
+    error::GoogleResponse,
+    object_access_control::{NewObjectAccessControl, ObjectAccessControl},
+    resources::common::ListResponse,
+};
+
+/// Operations on [`ObjectAccessControl`](ObjectAccessControl)s.
+pub struct ObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectAccessControlClient<'a> {
+    /// Creates a new ACL entry on the specified `object`.
+    ///
+    /// ### Important
+    /// This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn create(
+        &self,
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .post(&url)
+            .headers(self.0.get_headers().await?)
+            .json(new_object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Retrieves `ACL` entries on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn list(
+        &self,
+        bucket: &str,
+        object: &str,
+    ) -> crate::Result<Vec<ObjectAccessControl>> {
+        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
+        let result: GoogleResponse<ListResponse<ObjectAccessControl>> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s.items),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Returns the `ACL` entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn read(
+        &self,
+        bucket: &str,
+        object: &str,
+        entity: &Entity,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            bucket,
+            object,
+            entity
+        );
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .get(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Updates an ACL entry on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn update(
+        &self,
+        object_access_control: &ObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            object_access_control.bucket,
+            object_access_control.object,
+            object_access_control.entity,
+        );
+        let result: GoogleResponse<ObjectAccessControl> = self
+            .0
+            .client
+            .put(&url)
+            .headers(self.0.get_headers().await?)
+            .json(object_access_control)
+            .send()
+            .await?
+            .json()
+            .await?;
+        match result {
+            GoogleResponse::Success(s) => Ok(s),
+            GoogleResponse::Error(e) => Err(e.into()),
+        }
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub async fn delete(&self, object_access_control: ObjectAccessControl) -> crate::Result<()> {
+        let url = format!(
+            "{}/b/{}/o/{}/acl/{}",
+            crate::BASE_URL,
+            object_access_control.bucket,
+            object_access_control.object,
+            object_access_control.entity,
+        );
+        let response = self
+            .0
+            .client
+            .delete(&url)
+            .headers(self.0.get_headers().await?)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::Error::Google(response.json().await?))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@
 #![forbid(unsafe_code, missing_docs)]
 
 pub mod client;
+#[cfg(feature = "sync")]
+pub mod sync;
+
 mod download_options;
 mod error;
 /// Contains objects as represented by Google, to be used for serialization and deserialization.
@@ -206,7 +209,7 @@ async fn create_test_bucket(name: &str) -> Bucket {
     }
 }
 
-#[cfg(all(feature = "global-client", feature = "sync"))]
+#[cfg(feature = "sync")]
 fn runtime() -> Result<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_current_thread()
         .thread_name("cloud-storage-worker")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,29 +26,31 @@
 //! ## Examples:
 //! Creating a new Bucket in Google Cloud Storage:
 //! ```rust
-//! # use cloud_storage::{Bucket, NewBucket};
+//! # use cloud_storage::{Client, Bucket, NewBucket};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let bucket = Bucket::create(&NewBucket {
+//! let client = Client::default();
+//! let bucket = client.bucket().create(&NewBucket {
 //!     name: "doctest-bucket".to_string(),
 //!     ..Default::default()
 //! }).await?;
-//! # bucket.delete().await?;
+//! # client.bucket().delete(bucket).await?;
 //! # Ok(())
 //! # }
 //! ```
 //! Connecting to an existing Bucket in Google Cloud Storage:
 //! ```no_run
-//! # use cloud_storage::Bucket;
+//! # use cloud_storage::{Client, Bucket};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let bucket = Bucket::read("mybucket").await?;
+//! let client = Client::default();
+//! let bucket = client.bucket().read("mybucket").await?;
 //! # Ok(())
 //! # }
 //! ```
 //! Read a file from disk and store it on googles server:
 //! ```rust,no_run
-//! # use cloud_storage::Object;
+//! # use cloud_storage::{Client, Object};
 //! # use std::fs::File;
 //! # use std::io::Read;
 //! # #[tokio::main]
@@ -57,27 +59,30 @@
 //! for byte in File::open("myfile.txt")?.bytes() {
 //!     bytes.push(byte?)
 //! }
-//! Object::create("mybucket", bytes, "myfile.txt", "text/plain").await?;
+//! let client = Client::default();
+//! client.object().create("mybucket", bytes, "myfile.txt", "text/plain").await?;
 //! # Ok(())
 //! # }
 //! ```
 //! Renaming/moving a file
 //! ```rust,no_run
-//! # use cloud_storage::Object;
+//! # use cloud_storage::{Client, Object};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut object = Object::read("mybucket", "myfile").await?;
+//! let client = Client::default();
+//! let mut object = client.object().read("mybucket", "myfile").await?;
 //! object.name = "mybetterfile".to_string();
-//! object.update().await?;
+//! client.object().update(&object).await?;
 //! # Ok(())
 //! # }
 //! ```
 //! Removing a file
 //! ```rust,no_run
-//! # use cloud_storage::Object;
+//! # use cloud_storage::{Client, Object};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! Object::delete("mybucket", "myfile").await?;
+//! let client = Client::default();
+//! client.object().delete("mybucket", "myfile").await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -112,7 +117,10 @@ lazy_static::lazy_static! {
     /// debugging of which service account is currently used. It is of the type
     /// [ServiceAccount](service_account/struct.ServiceAccount.html).
     pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
+}
 
+#[cfg(feature = "global-client")]
+lazy_static::lazy_static! {
     static ref CLOUD_CLIENT: client::Client = client::Client::default();
 }
 
@@ -152,13 +160,12 @@ where
     }
 }
 
-#[cfg(test)]
-#[cfg(feature = "sync")]
+#[cfg(all(test, feature = "global-client", feature = "sync"))]
 fn read_test_bucket_sync() -> Bucket {
     crate::runtime().unwrap().block_on(read_test_bucket())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 async fn read_test_bucket() -> Bucket {
     dotenv::dotenv().ok();
     let name = std::env::var("TEST_BUCKET").unwrap();
@@ -175,15 +182,14 @@ async fn read_test_bucket() -> Bucket {
 
 // since all tests run in parallel, we need to make sure we do not create multiple buckets with
 // the same name in each test.
-#[cfg(test)]
-#[cfg(feature = "sync")]
+#[cfg(all(test, feature = "global-client", feature = "sync"))]
 fn create_test_bucket_sync(name: &str) -> Bucket {
     crate::runtime().unwrap().block_on(create_test_bucket(name))
 }
 
 // since all tests run in parallel, we need to make sure we do not create multiple buckets with
 // the same name in each test.
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 async fn create_test_bucket(name: &str) -> Bucket {
     std::thread::sleep(std::time::Duration::from_millis(1500)); // avoid getting rate limited
 
@@ -200,7 +206,7 @@ async fn create_test_bucket(name: &str) -> Bucket {
     }
 }
 
-#[cfg(feature = "sync")]
+#[cfg(all(feature = "global-client", feature = "sync"))]
 fn runtime() -> Result<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_current_thread()
         .thread_name("cloud-storage-worker")

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -557,6 +557,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create(new_bucket: &NewBucket) -> crate::Result<Self> {
         crate::CLOUD_CLIENT.bucket().create(new_bucket).await
     }
@@ -565,7 +566,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync(new_bucket: &NewBucket) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::create(new_bucket))
     }
@@ -585,6 +586,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn list() -> crate::Result<Vec<Self>> {
         crate::CLOUD_CLIENT.bucket().list().await
     }
@@ -593,7 +595,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync() -> crate::Result<Vec<Self>> {
         crate::runtime()?.block_on(Self::list())
     }
@@ -616,6 +618,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn read(name: &str) -> crate::Result<Self> {
         crate::CLOUD_CLIENT.bucket().read(name).await
     }
@@ -624,7 +627,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(name: &str) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::read(name))
     }
@@ -654,6 +657,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn update(&self) -> crate::Result<Self> {
         crate::CLOUD_CLIENT.bucket().update(self).await
     }
@@ -662,7 +666,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(&self) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.update())
     }
@@ -687,6 +691,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn delete(self) -> crate::Result<()> {
         crate::CLOUD_CLIENT.bucket().delete(self).await
     }
@@ -695,7 +700,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(self) -> crate::Result<()> {
         crate::runtime()?.block_on(self.delete())
     }
@@ -719,6 +724,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn get_iam_policy(&self) -> crate::Result<IamPolicy> {
         crate::CLOUD_CLIENT.bucket().get_iam_policy(self).await
     }
@@ -727,7 +733,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn get_iam_policy_sync(&self) -> crate::Result<IamPolicy> {
         crate::runtime()?.block_on(self.get_iam_policy())
     }
@@ -763,6 +769,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn set_iam_policy(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
         crate::CLOUD_CLIENT.bucket().set_iam_policy(self, iam).await
     }
@@ -771,7 +778,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn set_iam_policy_sync(&self, iam: &IamPolicy) -> crate::Result<IamPolicy> {
         crate::runtime()?.block_on(self.set_iam_policy(iam))
     }
@@ -788,6 +795,7 @@ impl Bucket {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn test_iam_permission(&self, permission: &str) -> crate::Result<TestIamPermission> {
         crate::CLOUD_CLIENT
             .bucket()
@@ -799,7 +807,7 @@ impl Bucket {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn test_iam_permission_sync(&self, permission: &str) -> crate::Result<TestIamPermission> {
         crate::runtime()?.block_on(self.test_iam_permission(permission))
     }
@@ -809,7 +817,7 @@ impl Bucket {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
     use crate::resources::common::Role;
@@ -905,7 +913,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     mod sync {
         use super::*;
         use crate::resources::common::Role;

--- a/src/resources/bucket_access_control.rs
+++ b/src/resources/bucket_access_control.rs
@@ -110,6 +110,7 @@ impl BucketAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create(
         bucket: &str,
         new_bucket_access_control: &NewBucketAccessControl,
@@ -124,7 +125,7 @@ impl BucketAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync(
         bucket: &str,
         new_bucket_access_control: &NewBucketAccessControl,
@@ -148,6 +149,7 @@ impl BucketAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         crate::CLOUD_CLIENT
             .bucket_access_control()
@@ -159,7 +161,7 @@ impl BucketAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync(bucket: &str) -> crate::Result<Vec<Self>> {
         crate::runtime()?.block_on(Self::list(bucket))
     }
@@ -180,6 +182,7 @@ impl BucketAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .bucket_access_control()
@@ -191,7 +194,7 @@ impl BucketAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::read(bucket, entity))
     }
@@ -214,6 +217,7 @@ impl BucketAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn update(&self) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .bucket_access_control()
@@ -225,7 +229,7 @@ impl BucketAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(&self) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.update())
     }
@@ -247,6 +251,7 @@ impl BucketAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn delete(self) -> crate::Result<()> {
         crate::CLOUD_CLIENT
             .bucket_access_control()
@@ -258,13 +263,13 @@ impl BucketAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(self) -> crate::Result<()> {
         crate::runtime()?.block_on(self.delete())
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
 
@@ -324,7 +329,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     mod sync {
         use super::*;
 

--- a/src/resources/bucket_access_control.rs
+++ b/src/resources/bucket_access_control.rs
@@ -1,5 +1,4 @@
 pub use crate::resources::common::{Entity, ProjectTeam, Role};
-use crate::{error::GoogleResponse, resources::common::ListResponse};
 
 /// The BucketAccessControl resource represents the Access Control Lists (ACLs) for buckets within
 /// Google Cloud Storage. ACLs let you specify who has access to your data and to what extent.
@@ -115,19 +114,10 @@ impl BucketAccessControl {
         bucket: &str,
         new_bucket_access_control: &NewBucketAccessControl,
     ) -> crate::Result<Self> {
-        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .post(&url)
-            .headers(crate::get_headers().await?)
-            .json(new_bucket_access_control)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .bucket_access_control()
+            .create(bucket, new_bucket_access_control)
+            .await
     }
 
     /// The synchronous equivalent of `BucketAccessControl::create`.
@@ -159,18 +149,10 @@ impl BucketAccessControl {
     /// # }
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
-        let url = format!("{}/b/{}/acl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s.items),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .bucket_access_control()
+            .list(bucket)
+            .await
     }
 
     /// The synchronous equivalent of `BucketAccessControl::list`.
@@ -199,18 +181,10 @@ impl BucketAccessControl {
     /// # }
     /// ```
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
-        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, bucket, entity);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .bucket_access_control()
+            .read(bucket, entity)
+            .await
     }
 
     /// The synchronous equivalent of `BucketAccessControl::read`.
@@ -241,19 +215,10 @@ impl BucketAccessControl {
     /// # }
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
-        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .put(&url)
-            .headers(crate::get_headers().await?)
-            .json(self)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .bucket_access_control()
+            .update(self)
+            .await
     }
 
     /// The synchronous equivalent of `BucketAccessControl::update`.
@@ -283,17 +248,10 @@ impl BucketAccessControl {
     /// # }
     /// ```
     pub async fn delete(self) -> crate::Result<()> {
-        let url = format!("{}/b/{}/acl/{}", crate::BASE_URL, self.bucket, self.entity);
-        let response = crate::CLIENT
-            .delete(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?;
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            Err(crate::Error::Google(response.json().await?))
-        }
+        crate::CLOUD_CLIENT
+            .bucket_access_control()
+            .delete(self)
+            .await
     }
 
     /// The synchronous equivalent of `BucketAccessControl::delete`.

--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -101,22 +101,10 @@ impl DefaultObjectAccessControl {
         bucket: &str,
         new_acl: &NewDefaultObjectAccessControl,
     ) -> crate::Result<Self> {
-        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .post(&url)
-            .headers(crate::get_headers().await?)
-            .json(new_acl)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(mut s) => {
-                s.bucket = bucket.to_string();
-                Ok(s)
-            }
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .default_object_access_control()
+            .create(bucket, new_acl)
+            .await
     }
 
     /// The synchronous equivalent of `DefautObjectAccessControl::create`.
@@ -147,25 +135,10 @@ impl DefaultObjectAccessControl {
     /// # }
     /// ```
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
-        let url = format!("{}/b/{}/defaultObjectAcl", crate::BASE_URL, bucket);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s
-                .items
-                .into_iter()
-                .map(|item| DefaultObjectAccessControl {
-                    bucket: bucket.to_string(),
-                    ..item
-                })
-                .collect()),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .default_object_access_control()
+            .list(bucket)
+            .await
     }
 
     /// The synchronous equivalent of `DefautObjectAccessControl::list`.
@@ -197,26 +170,10 @@ impl DefaultObjectAccessControl {
     /// # }
     /// ```
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/defaultObjectAcl/{}",
-            crate::BASE_URL,
-            bucket,
-            entity
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(mut s) => {
-                s.bucket = bucket.to_string();
-                Ok(s)
-            }
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .default_object_access_control()
+            .read(bucket, entity)
+            .await
     }
 
     /// The synchronous equivalent of `DefautObjectAccessControl::read`.
@@ -246,27 +203,10 @@ impl DefaultObjectAccessControl {
     /// # }
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/defaultObjectAcl/{}",
-            crate::BASE_URL,
-            self.bucket,
-            self.entity
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .put(&url)
-            .headers(crate::get_headers().await?)
-            .json(self)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(mut s) => {
-                s.bucket = self.bucket.to_string();
-                Ok(s)
-            }
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .default_object_access_control()
+            .update(self)
+            .await
     }
 
     /// The synchronous equivalent of `DefautObjectAccessControl::update`.
@@ -295,22 +235,10 @@ impl DefaultObjectAccessControl {
     /// # }
     /// ```
     pub async fn delete(self) -> Result<(), crate::Error> {
-        let url = format!(
-            "{}/b/{}/defaultObjectAcl/{}",
-            crate::BASE_URL,
-            self.bucket,
-            self.entity
-        );
-        let response = crate::CLIENT
-            .delete(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?;
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            Err(crate::Error::Google(response.json().await?))
-        }
+        crate::CLOUD_CLIENT
+            .default_object_access_control()
+            .delete(self)
+            .await
     }
 
     /// The synchronous equivalent of `DefautObjectAccessControl::delete`.

--- a/src/resources/default_object_access_control.rs
+++ b/src/resources/default_object_access_control.rs
@@ -97,6 +97,7 @@ impl DefaultObjectAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create(
         bucket: &str,
         new_acl: &NewDefaultObjectAccessControl,
@@ -111,7 +112,7 @@ impl DefaultObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync(
         bucket: &str,
         new_acl: &NewDefaultObjectAccessControl,
@@ -134,6 +135,7 @@ impl DefaultObjectAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn list(bucket: &str) -> crate::Result<Vec<Self>> {
         crate::CLOUD_CLIENT
             .default_object_access_control()
@@ -145,7 +147,7 @@ impl DefaultObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync(bucket: &str) -> crate::Result<Vec<Self>> {
         crate::runtime()?.block_on(Self::list(bucket))
     }
@@ -169,6 +171,7 @@ impl DefaultObjectAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn read(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .default_object_access_control()
@@ -180,7 +183,7 @@ impl DefaultObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(bucket: &str, entity: &Entity) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::read(bucket, entity))
     }
@@ -202,6 +205,7 @@ impl DefaultObjectAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn update(&self) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .default_object_access_control()
@@ -213,7 +217,7 @@ impl DefaultObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(&self) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.update())
     }
@@ -234,6 +238,7 @@ impl DefaultObjectAccessControl {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn delete(self) -> Result<(), crate::Error> {
         crate::CLOUD_CLIENT
             .default_object_access_control()
@@ -245,13 +250,13 @@ impl DefaultObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(self) -> Result<(), crate::Error> {
         crate::runtime()?.block_on(self.delete())
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
 
@@ -306,7 +311,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     mod sync {
         use super::*;
 

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -95,6 +95,7 @@ impl HmacKey {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create() -> crate::Result<Self> {
         crate::CLOUD_CLIENT.hmac_key().create().await
     }
@@ -103,7 +104,7 @@ impl HmacKey {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync() -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::create())
     }
@@ -127,6 +128,7 @@ impl HmacKey {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn list() -> crate::Result<Vec<HmacMeta>> {
         crate::CLOUD_CLIENT.hmac_key().list().await
     }
@@ -135,7 +137,7 @@ impl HmacKey {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync() -> crate::Result<Vec<HmacMeta>> {
         crate::runtime()?.block_on(Self::list())
     }
@@ -158,6 +160,7 @@ impl HmacKey {
     /// let key = HmacKey::read("some identifier").await?;
     /// # Ok(())
     /// # }
+    #[cfg(feature = "global-client")]
     pub async fn read(access_id: &str) -> crate::Result<HmacMeta> {
         crate::CLOUD_CLIENT.hmac_key().read(access_id).await
     }
@@ -166,7 +169,7 @@ impl HmacKey {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(access_id: &str) -> crate::Result<HmacMeta> {
         crate::runtime()?.block_on(Self::read(access_id))
     }
@@ -189,6 +192,7 @@ impl HmacKey {
     /// let key = HmacKey::update("your key", HmacState::Active).await?;
     /// # Ok(())
     /// # }
+    #[cfg(feature = "global-client")]
     pub async fn update(access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
         crate::CLOUD_CLIENT
             .hmac_key()
@@ -200,7 +204,7 @@ impl HmacKey {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
         crate::runtime()?.block_on(Self::update(access_id, state))
     }
@@ -222,18 +226,19 @@ impl HmacKey {
     /// HmacKey::delete(&key.access_id).await?;
     /// # Ok(())
     /// # }
+    #[cfg(feature = "global-client")]
     pub async fn delete(access_id: &str) -> crate::Result<()> {
         crate::CLOUD_CLIENT.hmac_key().delete(access_id).await
     }
 
     /// The synchronous equivalent of `HmacKey::delete`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(access_id: &str) -> crate::Result<()> {
         crate::runtime()?.block_on(Self::delete(access_id))
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
 
@@ -300,7 +305,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     mod sync {
         use super::*;
 

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -1,6 +1,8 @@
 pub use crate::resources::bucket::Owner;
 use crate::resources::object_access_control::ObjectAccessControl;
-use futures::{Stream, TryStream};
+use futures::Stream;
+#[cfg(feature = "global-client")]
+use futures::TryStream;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use std::collections::HashMap;
 
@@ -249,6 +251,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create(
         bucket: &str,
         file: Vec<u8>,
@@ -265,7 +268,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync(
         bucket: &str,
         file: Vec<u8>,
@@ -292,6 +295,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn create_streamed<S>(
         bucket: &str,
         stream: S,
@@ -314,7 +318,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_streamed_sync<R: std::io::Read + Send + 'static>(
         bucket: &str,
         mut file: R,
@@ -347,6 +351,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn list(
         bucket: &str,
         list_request: ListRequest,
@@ -361,7 +366,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync(bucket: &str, list_request: ListRequest) -> crate::Result<Vec<ObjectList>> {
         use futures::TryStreamExt;
 
@@ -381,6 +386,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn read(bucket: &str, file_name: &str) -> crate::Result<Self> {
         crate::CLOUD_CLIENT.object().read(bucket, file_name).await
     }
@@ -389,7 +395,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(bucket: &str, file_name: &str) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::read(bucket, file_name))
     }
@@ -405,6 +411,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn download(bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
         crate::CLOUD_CLIENT
             .object()
@@ -416,7 +423,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn download_sync(bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
         crate::runtime()?.block_on(Self::download(bucket, file_name))
     }
@@ -440,6 +447,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn download_streamed(
         bucket: &str,
         file_name: &str,
@@ -463,6 +471,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn update(&self) -> crate::Result<Self> {
         crate::CLOUD_CLIENT.object().update(self).await
     }
@@ -471,7 +480,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(&self) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.update())
     }
@@ -487,6 +496,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn delete(bucket: &str, file_name: &str) -> crate::Result<()> {
         crate::CLOUD_CLIENT.object().delete(bucket, file_name).await
     }
@@ -495,7 +505,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(bucket: &str, file_name: &str) -> crate::Result<()> {
         crate::runtime()?.block_on(Self::delete(bucket, file_name))
     }
@@ -530,6 +540,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn compose(
         bucket: &str,
         req: &ComposeRequest,
@@ -545,7 +556,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn compose_sync(
         bucket: &str,
         req: &ComposeRequest,
@@ -567,6 +578,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn copy(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .object()
@@ -578,7 +590,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn copy_sync(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.copy(destination_bucket, path))
     }
@@ -603,6 +615,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "global-client")]
     pub async fn rewrite(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .object()
@@ -614,7 +627,7 @@ impl Object {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn rewrite_sync(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.rewrite(destination_bucket, path))
     }
@@ -626,9 +639,10 @@ impl Object {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use cloud_storage::object::{Object, ComposeRequest};
+    /// use cloud_storage::{Client, object::{Object, ComposeRequest}};
     ///
-    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
     /// let url = obj1.download_url(50)?;
     /// // url is now a url to which an unauthenticated user can make a request to download a file
     /// // for 50 seconds.
@@ -646,9 +660,10 @@ impl Object {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use cloud_storage::object::{Object, ComposeRequest};
+    /// use cloud_storage::{Client, object::{Object, ComposeRequest}};
     ///
-    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
     /// let url = obj1.download_url(50)?;
     /// // url is now a url to which an unauthenticated user can make a request to download a file
     /// // for 50 seconds.
@@ -676,9 +691,10 @@ impl Object {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use cloud_storage::object::{Object, ComposeRequest};
+    /// use cloud_storage::{Client, object::{Object, ComposeRequest}};
     ///
-    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
     /// let url = obj1.upload_url(50)?;
     /// // url is now a url to which an unauthenticated user can make a PUT request to upload a file
     /// // for 50 seconds.
@@ -696,10 +712,11 @@ impl Object {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use cloud_storage::object::{Object, ComposeRequest};
+    /// use cloud_storage::{Client, object::{Object, ComposeRequest}};
     /// use std::collections::HashMap;
     ///
-    /// let obj1 = Object::read("my_bucket", "file1").await?;
+    /// let client = Client::default();
+    /// let obj1 = client.object().read("my_bucket", "file1").await?;
     /// let mut custom_metadata = HashMap::new();
     /// custom_metadata.insert(String::from("field"), String::from("value"));
     /// let (url, headers) = obj1.upload_url_with(50, custom_metadata)?;
@@ -912,7 +929,7 @@ pub(crate) fn percent_encode(input: &str) -> String {
     utf8_percent_encode(input, ENCODE_SET).to_string()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
     use crate::Error;

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -1,11 +1,7 @@
 pub use crate::resources::bucket::Owner;
-use crate::{
-    error::{Error, GoogleResponse},
-    resources::object_access_control::ObjectAccessControl,
-};
-use futures::{stream, Stream, TryStream};
+use crate::resources::object_access_control::ObjectAccessControl;
+use futures::{Stream, TryStream};
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
-use reqwest::StatusCode;
 use std::collections::HashMap;
 
 /// A resource representing a file in Google Cloud Storage.
@@ -229,12 +225,12 @@ pub struct ObjectList {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RewriteResponse {
-    kind: String,
-    total_bytes_rewritten: String,
-    object_size: String,
-    done: bool,
-    resource: Object,
+pub(crate) struct RewriteResponse {
+    pub(crate) kind: String,
+    pub(crate) total_bytes_rewritten: String,
+    pub(crate) object_size: String,
+    pub(crate) done: bool,
+    pub(crate) resource: Object,
 }
 
 impl Object {
@@ -259,30 +255,10 @@ impl Object {
         filename: &str,
         mime_type: &str,
     ) -> crate::Result<Self> {
-        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
-
-        // has its own url for some reason
-        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
-        let url = &format!(
-            "{}/{}/o?uploadType=media&name={}",
-            BASE_URL,
-            percent_encode(&bucket),
-            percent_encode(&filename),
-        );
-        let mut headers = crate::get_headers().await?;
-        headers.insert(CONTENT_TYPE, mime_type.parse()?);
-        headers.insert(CONTENT_LENGTH, file.len().to_string().parse()?);
-        let response = crate::CLIENT
-            .post(url)
-            .headers(headers)
-            .body(file)
-            .send()
-            .await?;
-        if response.status() == 200 {
-            Ok(serde_json::from_str(&response.text().await?)?)
-        } else {
-            Err(Error::new(&response.text().await?))
-        }
+        crate::CLOUD_CLIENT
+            .object()
+            .create(bucket, file, filename, mime_type)
+            .await
     }
 
     /// The synchronous equivalent of `Object::create`.
@@ -328,34 +304,10 @@ impl Object {
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         bytes::Bytes: From<S::Ok>,
     {
-        use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
-
-        // has its own url for some reason
-        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
-        let url = &format!(
-            "{}/{}/o?uploadType=media&name={}",
-            BASE_URL,
-            percent_encode(&bucket),
-            percent_encode(&filename),
-        );
-        let mut headers = crate::get_headers().await?;
-        headers.insert(CONTENT_TYPE, mime_type.parse()?);
-        if let Some(length) = length.into() {
-            headers.insert(CONTENT_LENGTH, length.into());
-        }
-
-        let body = reqwest::Body::wrap_stream(stream);
-        let response = crate::CLIENT
-            .post(url)
-            .headers(headers)
-            .body(body)
-            .send()
-            .await?;
-        if response.status() == 200 {
-            Ok(serde_json::from_str(&response.text().await?)?)
-        } else {
-            Err(Error::new(&response.text().await?))
-        }
+        crate::CLOUD_CLIENT
+            .object()
+            .create_streamed(bucket, stream, length, filename, mime_type)
+            .await
     }
 
     /// The synchronous equivalent of `Object::create_streamed`.
@@ -372,9 +324,9 @@ impl Object {
     ) -> crate::Result<Self> {
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)
-            .map_err(|e| Error::Other(e.to_string()))?;
+            .map_err(|e| crate::Error::Other(e.to_string()))?;
 
-        let stream = stream::once(async { Ok::<_, Error>(buffer) });
+        let stream = futures::stream::once(async { Ok::<_, crate::Error>(buffer) });
 
         crate::runtime()?.block_on(Self::create_streamed(
             bucket, stream, length, filename, mime_type,
@@ -398,84 +350,11 @@ impl Object {
     pub async fn list(
         bucket: &str,
         list_request: ListRequest,
-    ) -> Result<impl Stream<Item = Result<ObjectList, Error>> + '_, Error> {
-        enum ListState {
-            Start(ListRequest),
-            HasMore(ListRequest),
-            Done,
-        }
-        use ListState::*;
-        impl ListState {
-            fn into_has_more(self) -> Option<ListState> {
-                match self {
-                    Start(req) | HasMore(req) => Some(HasMore(req)),
-                    Done => None,
-                }
-            }
-
-            fn req_mut(&mut self) -> Option<&mut ListRequest> {
-                match self {
-                    Start(ref mut req) | HasMore(ref mut req) => Some(req),
-                    Done => return None,
-                }
-            }
-        }
-
-        Ok(stream::unfold(
-            ListState::Start(list_request),
-            move |mut state| async move {
-                let url = format!("{}/b/{}/o", crate::BASE_URL, percent_encode(bucket));
-                let headers = match crate::get_headers().await {
-                    Ok(h) => h,
-                    Err(e) => return Some((Err(e), state)),
-                };
-                let req = state.req_mut()?;
-                if req.max_results == Some(0) {
-                    return None;
-                }
-
-                let response = crate::CLIENT
-                    .get(&url)
-                    .query(req)
-                    .headers(headers)
-                    .send()
-                    .await;
-
-                let response = match response {
-                    Ok(r) if r.status() == 200 => r,
-                    Ok(r) => {
-                        let e = match r.json::<crate::error::GoogleErrorResponse>().await {
-                            Ok(err_res) => err_res.into(),
-                            Err(serde_err) => serde_err.into(),
-                        };
-                        return Some((Err(e), state));
-                    }
-                    Err(e) => return Some((Err(e.into()), state)),
-                };
-
-                let result: GoogleResponse<ObjectList> = match response.json().await {
-                    Ok(json) => json,
-                    Err(e) => return Some((Err(e.into()), state)),
-                };
-
-                let response_body = match result {
-                    GoogleResponse::Success(success) => success,
-                    GoogleResponse::Error(e) => return Some((Err(e.into()), state)),
-                };
-
-                let next_state = if let Some(ref page_token) = response_body.next_page_token {
-                    req.page_token = Some(page_token.clone());
-                    req.max_results = req
-                        .max_results
-                        .map(|rem| rem.saturating_sub(response_body.items.len()));
-                    state.into_has_more()?
-                } else {
-                    Done
-                };
-
-                Some((Ok(response_body), next_state))
-            },
-        ))
+    ) -> crate::Result<impl Stream<Item = crate::Result<ObjectList>> + '_> {
+        crate::CLOUD_CLIENT
+            .object()
+            .list(bucket, list_request)
+            .await
     }
 
     /// The synchronous equivalent of `Object::list`.
@@ -483,7 +362,7 @@ impl Object {
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
     #[cfg(feature = "sync")]
-    pub fn list_sync(bucket: &str, list_request: ListRequest) -> Result<Vec<ObjectList>, Error> {
+    pub fn list_sync(bucket: &str, list_request: ListRequest) -> crate::Result<Vec<ObjectList>> {
         use futures::TryStreamExt;
 
         let rt = crate::runtime()?;
@@ -503,23 +382,7 @@ impl Object {
     /// # }
     /// ```
     pub async fn read(bucket: &str, file_name: &str) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/o/{}",
-            crate::BASE_URL,
-            percent_encode(bucket),
-            percent_encode(file_name),
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT.object().read(bucket, file_name).await
     }
 
     /// The synchronous equivalent of `Object::read`.
@@ -542,23 +405,11 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn download(bucket: &str, file_name: &str) -> Result<Vec<u8>, Error> {
-        let url = format!(
-            "{}/b/{}/o/{}?alt=media",
-            crate::BASE_URL,
-            percent_encode(bucket),
-            percent_encode(file_name),
-        );
-        let resp = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?;
-        if resp.status() == StatusCode::NOT_FOUND {
-            Err(Error::Other(resp.text().await?))
-        } else {
-            Ok(resp.error_for_status()?.bytes().await?.to_vec())
-        }
+    pub async fn download(bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        crate::CLOUD_CLIENT
+            .object()
+            .download(bucket, file_name)
+            .await
     }
 
     /// The synchronous equivalent of `Object::download`.
@@ -593,25 +444,10 @@ impl Object {
         bucket: &str,
         file_name: &str,
     ) -> crate::Result<impl Stream<Item = crate::Result<u8>> + Unpin> {
-        use futures::{StreamExt, TryStreamExt};
-        let url = format!(
-            "{}/b/{}/o/{}?alt=media",
-            crate::BASE_URL,
-            percent_encode(bucket),
-            percent_encode(file_name),
-        );
-        let response = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .error_for_status()?;
-        let size = response.content_length();
-        let bytes = response
-            .bytes_stream()
-            .map(|chunk| chunk.map(|c| futures::stream::iter(c.into_iter().map(Ok))))
-            .try_flatten();
-        Ok(SizedByteStream::new(bytes, size))
+        crate::CLOUD_CLIENT
+            .object()
+            .download_streamed(bucket, file_name)
+            .await
     }
 
     /// Obtains a single object with the specified name in the specified bucket.
@@ -628,24 +464,7 @@ impl Object {
     /// # }
     /// ```
     pub async fn update(&self) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/o/{}",
-            crate::BASE_URL,
-            percent_encode(&self.bucket),
-            percent_encode(&self.name),
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .put(&url)
-            .headers(crate::get_headers().await?)
-            .json(&self)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT.object().update(self).await
     }
 
     /// The synchronous equivalent of `Object::download`.
@@ -668,23 +487,8 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete(bucket: &str, file_name: &str) -> Result<(), Error> {
-        let url = format!(
-            "{}/b/{}/o/{}",
-            crate::BASE_URL,
-            percent_encode(bucket),
-            percent_encode(file_name),
-        );
-        let response = crate::CLIENT
-            .delete(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?;
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            Err(Error::Google(response.json().await?))
-        }
+    pub async fn delete(bucket: &str, file_name: &str) -> crate::Result<()> {
+        crate::CLOUD_CLIENT.object().delete(bucket, file_name).await
     }
 
     /// The synchronous equivalent of `Object::delete`.
@@ -692,7 +496,7 @@ impl Object {
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
     #[cfg(feature = "sync")]
-    pub fn delete_sync(bucket: &str, file_name: &str) -> Result<(), Error> {
+    pub fn delete_sync(bucket: &str, file_name: &str) -> crate::Result<()> {
         crate::runtime()?.block_on(Self::delete(bucket, file_name))
     }
 
@@ -731,24 +535,10 @@ impl Object {
         req: &ComposeRequest,
         destination_object: &str,
     ) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/o/{}/compose",
-            crate::BASE_URL,
-            percent_encode(&bucket),
-            percent_encode(&destination_object)
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .post(&url)
-            .headers(crate::get_headers().await?)
-            .json(req)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object()
+            .compose(bucket, req, destination_object)
+            .await
     }
 
     /// The synchronous equivalent of `Object::compose`.
@@ -778,29 +568,10 @@ impl Object {
     /// # }
     /// ```
     pub async fn copy(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
-        use reqwest::header::CONTENT_LENGTH;
-
-        let url = format!(
-            "{base}/b/{sBucket}/o/{sObject}/copyTo/b/{dBucket}/o/{dObject}",
-            base = crate::BASE_URL,
-            sBucket = percent_encode(&self.bucket),
-            sObject = percent_encode(&self.name),
-            dBucket = percent_encode(&destination_bucket),
-            dObject = percent_encode(&path),
-        );
-        let mut headers = crate::get_headers().await?;
-        headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .post(&url)
-            .headers(headers)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object()
+            .copy(self, destination_bucket, path)
+            .await
     }
 
     /// The synchronous equivalent of `Object::copy`.
@@ -833,29 +604,10 @@ impl Object {
     /// # }
     /// ```
     pub async fn rewrite(&self, destination_bucket: &str, path: &str) -> crate::Result<Self> {
-        use reqwest::header::CONTENT_LENGTH;
-
-        let url = format!(
-            "{base}/b/{sBucket}/o/{sObject}/rewriteTo/b/{dBucket}/o/{dObject}",
-            base = crate::BASE_URL,
-            sBucket = percent_encode(&self.bucket),
-            sObject = percent_encode(&self.name),
-            dBucket = percent_encode(destination_bucket),
-            dObject = percent_encode(path),
-        );
-        let mut headers = crate::get_headers().await?;
-        headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let result: GoogleResponse<RewriteResponse> = crate::CLIENT
-            .post(&url)
-            .headers(headers)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s.resource),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object()
+            .rewrite(self, destination_bucket, path)
+            .await
     }
 
     /// The synchronous equivalent of `Object::rewrite`.
@@ -992,7 +744,7 @@ impl Object {
                 "duration may not be greater than 604800, but was {}",
                 duration
             );
-            return Err(Error::Other(msg));
+            return Err(crate::Error::Other(msg));
         }
 
         // 0 Sort and construct the canonical headers
@@ -1132,7 +884,7 @@ impl Object {
     }
 
     #[inline(always)]
-    fn sign_str(message: &str) -> Result<Vec<u8>, Error> {
+    fn sign_str(message: &str) -> crate::Result<Vec<u8>> {
         use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
 
         let key = PKey::private_key_from_pem(crate::SERVICE_ACCOUNT.private_key.as_bytes())?;
@@ -1156,14 +908,15 @@ fn percent_encode_noslash(input: &str) -> String {
     utf8_percent_encode(input, NOSLASH_ENCODE_SET).to_string()
 }
 
-fn percent_encode(input: &str) -> String {
+pub(crate) fn percent_encode(input: &str) -> String {
     utf8_percent_encode(input, ENCODE_SET).to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{StreamExt, TryStreamExt};
+    use crate::Error;
+    use futures::{stream, StreamExt, TryStreamExt};
 
     #[tokio::test]
     async fn create() -> Result<(), Box<dyn std::error::Error>> {
@@ -1388,7 +1141,8 @@ mod tests {
         let obj = Object::create(&bucket.name, vec![0, 1], "test-rewrite", "text/plain").await?;
         let obj = obj.rewrite(&bucket.name, "test-rewritten").await?;
         let url = obj.download_url(100)?;
-        let download = crate::CLIENT.head(&url).send().await?;
+        let client = reqwest::Client::default();
+        let download = client.head(&url).send().await?;
         assert_eq!(download.status().as_u16(), 200);
         Ok(())
     }
@@ -1408,7 +1162,8 @@ mod tests {
             let _obj = Object::create(&bucket.name, vec![0, 1], name, "text/plain").await?;
             let obj = Object::read(&bucket.name, &name).await.unwrap();
             let url = obj.download_url(100)?;
-            let download = crate::CLIENT.head(&url).send().await?;
+            let client = reqwest::Client::default();
+            let download = client.head(&url).send().await?;
             assert_eq!(download.status().as_u16(), 200);
         }
         Ok(())
@@ -1714,7 +1469,7 @@ pub struct SizedByteStream<S: Stream<Item = crate::Result<u8>> + Unpin> {
 }
 
 impl<S: Stream<Item = crate::Result<u8>> + Unpin> SizedByteStream<S> {
-    fn new(bytes: S, size: Option<u64>) -> Self {
+    pub(crate) fn new(bytes: S, size: Option<u64>) -> Self {
         Self { bytes, size }
     }
 }

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -109,6 +109,7 @@ impl ObjectAccessControl {
     /// This method fails with a 400 Bad Request response for buckets with uniform
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
+    #[cfg(feature = "global-client")]
     pub async fn create(
         bucket: &str,
         object: &str,
@@ -124,7 +125,7 @@ impl ObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn create_sync(
         bucket: &str,
         object: &str,
@@ -139,6 +140,7 @@ impl ObjectAccessControl {
     /// Important: This method fails with a 400 Bad Request response for buckets with uniform
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
+    #[cfg(feature = "global-client")]
     pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
         crate::CLOUD_CLIENT
             .object_access_control()
@@ -150,7 +152,7 @@ impl ObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
         crate::runtime()?.block_on(Self::list(bucket, object))
     }
@@ -161,6 +163,7 @@ impl ObjectAccessControl {
     /// Important: This method fails with a 400 Bad Request response for buckets with uniform
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
+    #[cfg(feature = "global-client")]
     pub async fn read(bucket: &str, object: &str, entity: &Entity) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .object_access_control()
@@ -172,7 +175,7 @@ impl ObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn read_sync(bucket: &str, object: &str, entity: &Entity) -> crate::Result<Self> {
         crate::runtime()?.block_on(Self::read(bucket, object, entity))
     }
@@ -183,6 +186,7 @@ impl ObjectAccessControl {
     /// Important: This method fails with a 400 Bad Request response for buckets with uniform
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
+    #[cfg(feature = "global-client")]
     pub async fn update(&self) -> crate::Result<Self> {
         crate::CLOUD_CLIENT
             .object_access_control()
@@ -194,7 +198,7 @@ impl ObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn update_sync(&self) -> crate::Result<Self> {
         crate::runtime()?.block_on(self.update())
     }
@@ -205,6 +209,7 @@ impl ObjectAccessControl {
     /// Important: This method fails with a 400 Bad Request response for buckets with uniform
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
+    #[cfg(feature = "global-client")]
     pub async fn delete(self) -> crate::Result<()> {
         crate::CLOUD_CLIENT
             .object_access_control()
@@ -216,13 +221,13 @@ impl ObjectAccessControl {
     ///
     /// ### Features
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn delete_sync(self) -> crate::Result<()> {
         crate::runtime()?.block_on(self.delete())
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-client"))]
 mod tests {
     use super::*;
     use crate::Object;
@@ -343,7 +348,7 @@ mod tests {
         bucket.delete().await.unwrap();
     }
 
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "global-client", feature = "sync"))]
     mod sync {
         use super::*;
 

--- a/src/resources/object_access_control.rs
+++ b/src/resources/object_access_control.rs
@@ -114,19 +114,10 @@ impl ObjectAccessControl {
         object: &str,
         new_object_access_control: &NewObjectAccessControl,
     ) -> crate::Result<Self> {
-        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .post(&url)
-            .headers(crate::get_headers().await?)
-            .json(new_object_access_control)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object_access_control()
+            .create(bucket, object, new_object_access_control)
+            .await
     }
 
     /// The synchronous equivalent of `ObjectAccessControl::create`.
@@ -149,18 +140,10 @@ impl ObjectAccessControl {
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
     pub async fn list(bucket: &str, object: &str) -> crate::Result<Vec<Self>> {
-        let url = format!("{}/b/{}/o/{}/acl", crate::BASE_URL, bucket, object);
-        let result: GoogleResponse<ListResponse<Self>> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s.items),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object_access_control()
+            .list(bucket, object)
+            .await
     }
 
     /// The synchronous equivalent of `ObjectAccessControl::list`.
@@ -179,24 +162,10 @@ impl ObjectAccessControl {
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
     pub async fn read(bucket: &str, object: &str, entity: &Entity) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/o/{}/acl/{}",
-            crate::BASE_URL,
-            bucket,
-            object,
-            entity
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .get(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object_access_control()
+            .read(bucket, object, entity)
+            .await
     }
 
     /// The synchronous equivalent of `ObjectAccessControl::read`.
@@ -215,25 +184,10 @@ impl ObjectAccessControl {
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
     pub async fn update(&self) -> crate::Result<Self> {
-        let url = format!(
-            "{}/b/{}/o/{}/acl/{}",
-            crate::BASE_URL,
-            self.bucket,
-            self.object,
-            self.entity,
-        );
-        let result: GoogleResponse<Self> = crate::CLIENT
-            .put(&url)
-            .headers(crate::get_headers().await?)
-            .json(self)
-            .send()
-            .await?
-            .json()
-            .await?;
-        match result {
-            GoogleResponse::Success(s) => Ok(s),
-            GoogleResponse::Error(e) => Err(e.into()),
-        }
+        crate::CLOUD_CLIENT
+            .object_access_control()
+            .update(self)
+            .await
     }
 
     /// The synchronous equivalent of `ObjectAccessControl::update`.
@@ -252,23 +206,10 @@ impl ObjectAccessControl {
     /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
     /// control access instead.
     pub async fn delete(self) -> crate::Result<()> {
-        let url = format!(
-            "{}/b/{}/o/{}/acl/{}",
-            crate::BASE_URL,
-            self.bucket,
-            self.object,
-            self.entity,
-        );
-        let response = crate::CLIENT
-            .delete(&url)
-            .headers(crate::get_headers().await?)
-            .send()
-            .await?;
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            Err(crate::Error::Google(response.json().await?))
-        }
+        crate::CLOUD_CLIENT
+            .object_access_control()
+            .delete(self)
+            .await
     }
 
     /// The synchronous equivalent of `ObjectAccessControl::delete`.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,61 @@
+//! Synchronous clients for Google Cloud Storage endpoints.
+
+mod bucket;
+mod bucket_access_control;
+mod default_object_access_control;
+mod hmac_key;
+mod object;
+mod object_access_control;
+
+pub use bucket::BucketClient;
+pub use bucket_access_control::BucketAccessControlClient;
+pub use default_object_access_control::DefaultObjectAccessControlClient;
+pub use hmac_key::HmacKeyClient;
+pub use object::ObjectClient;
+pub use object_access_control::ObjectAccessControlClient;
+
+/// The primary synchronous entrypoint to perform operations with Google Cloud Storage.
+pub struct Client {
+    runtime: tokio::runtime::Runtime,
+    client: crate::client::Client,
+}
+
+impl Client {
+    /// Constructs a synchronous client
+    pub fn new() -> crate::Result<Self> {
+        Ok(Self {
+            runtime: crate::runtime()?,
+            client: Default::default(),
+        })
+    }
+
+    /// Synchronous operations on [`Bucket`](crate::bucket::Bucket)s.
+    pub fn bucket(&self) -> BucketClient<'_> {
+        BucketClient(self)
+    }
+
+    /// Synchronous operations on [`BucketAccessControl`](crate::bucket_access_control::BucketAccessControl)s.
+    pub fn bucket_access_control(&self) -> BucketAccessControlClient<'_> {
+        BucketAccessControlClient(self)
+    }
+
+    /// Synchronous operations on [`DefaultObjectAccessControl`](crate::default_object_access_control::DefaultObjectAccessControl)s.
+    pub fn default_object_access_control(&self) -> DefaultObjectAccessControlClient<'_> {
+        DefaultObjectAccessControlClient(self)
+    }
+
+    /// Synchronous operations on [`HmacKey`](crate::hmac_key::HmacKey)s.
+    pub fn hmac_key(&self) -> HmacKeyClient<'_> {
+        HmacKeyClient(self)
+    }
+
+    /// Synchronous operations on [`Object`](crate::object::Object)s.
+    pub fn object(&self) -> ObjectClient<'_> {
+        ObjectClient(self)
+    }
+
+    /// Synchronous operations on [`ObjectAccessControl`](crate::object_access_control::ObjectAccessControl)s.
+    pub fn object_access_control(&self) -> ObjectAccessControlClient<'_> {
+        ObjectAccessControlClient(self)
+    }
+}

--- a/src/sync/bucket.rs
+++ b/src/sync/bucket.rs
@@ -1,0 +1,234 @@
+use crate::{
+    bucket::{IamPolicy, TestIamPermission},
+    Bucket, NewBucket,
+};
+
+/// Operations on [`Bucket`]()s.
+pub struct BucketClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketClient<'a> {
+    /// Creates a new `Bucket`. There are many options that you can provide for creating a new
+    /// bucket, so the `NewBucket` resource contains all of them. Note that `NewBucket` implements
+    /// `Default`, so you don't have to specify the fields you're not using. And error is returned
+    /// if that bucket name is already taken.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket::{Bucket, NewBucket};
+    /// use cloud_storage::bucket::{Location, MultiRegion};
+    ///
+    /// let client = Client::new()?;
+    /// let new_bucket = NewBucket {
+    ///    name: "cloud-storage-rs-doc-1".to_string(), // this is the only mandatory field
+    ///    location: Location::Multi(MultiRegion::Eu),
+    ///    ..Default::default()
+    /// };
+    /// let bucket = client.bucket().create(&new_bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(&self, new_bucket: &NewBucket) -> crate::Result<Bucket> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().create(new_bucket))
+    }
+
+    /// Returns all `Bucket`s within this project.
+    ///
+    /// ### Note
+    /// When using incorrect permissions, this function fails silently and returns an empty list.
+    ///
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// let buckets = client.bucket().list()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self) -> crate::Result<Vec<Bucket>> {
+        self.0.runtime.block_on(self.0.client.bucket().list())
+    }
+
+    /// Returns a single `Bucket` by its name. If the Bucket does not exist, an error is returned.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-2".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-2")?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, name: &str) -> crate::Result<Bucket> {
+        self.0.runtime.block_on(self.0.client.bucket().read(name))
+    }
+
+    /// Update an existing `Bucket`. If you declare you bucket as mutable, you can edit its fields.
+    /// You can then flush your changes to Google Cloud Storage using this method.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket::{Bucket, RetentionPolicy};
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-3".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3")?;
+    /// bucket.retention_policy = Some(RetentionPolicy {
+    ///     retention_period: 50,
+    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     is_locked: Some(false),
+    /// });
+    /// client.bucket().update(&bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(&self, bucket: &Bucket) -> crate::Result<Bucket> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().update(bucket))
+    }
+
+    /// Delete an existing `Bucket`. This permanently removes a bucket from Google Cloud Storage.
+    /// An error is returned when you don't have sufficient permissions, or when the
+    /// `retention_policy` prevents you from deleting your Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "unnecessary-bucket".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("unnecessary-bucket")?;
+    /// client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket: Bucket) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().delete(bucket))
+    }
+
+    /// Returns the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-4".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-4")?;
+    /// let policy = client.bucket().get_iam_policy(&bucket)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_iam_policy(&self, bucket: &Bucket) -> crate::Result<IamPolicy> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().get_iam_policy(bucket))
+    }
+
+    /// Updates the [IAM Policy](https://cloud.google.com/iam/docs/) for this bucket.
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    /// use cloud_storage::bucket::{IamPolicy, Binding, IamRole, StandardIamRole, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// # use cloud_storage::bucket::NewBucket;
+    /// # let new_bucket = NewBucket {
+    /// #   name: "cloud-storage-rs-doc-5".to_string(),
+    /// #    ..Default::default()
+    /// # };
+    /// # let _ = client.bucket().create(&new_bucket)?;
+    ///
+    /// let bucket = client.bucket().read("cloud-storage-rs-doc-5")?;
+    /// let iam_policy = IamPolicy {
+    ///     version: 1,
+    ///     bindings: vec![
+    ///         Binding {
+    ///             role: IamRole::Standard(StandardIamRole::ObjectViewer),
+    ///             members: vec!["allUsers".to_string()],
+    ///             condition: None,
+    ///         }
+    ///     ],
+    ///     ..Default::default()
+    /// };
+    /// let policy = client.bucket().set_iam_policy(&bucket, &iam_policy)?;
+    /// # client.bucket().delete(bucket)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_iam_policy(&self, bucket: &Bucket, iam: &IamPolicy) -> crate::Result<IamPolicy> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket().set_iam_policy(bucket, iam))
+    }
+
+    /// Checks whether the user provided in the service account has this permission.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Bucket;
+    ///
+    /// let client = Client::new()?;
+    /// let bucket = client.bucket().read("my-bucket")?;
+    /// client.bucket().test_iam_permission(&bucket, "storage.buckets.get")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn test_iam_permission(
+        &self,
+        bucket: &Bucket,
+        permission: &str,
+    ) -> crate::Result<TestIamPermission> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket()
+                .test_iam_permission(bucket, permission),
+        )
+    }
+}

--- a/src/sync/bucket_access_control.rs
+++ b/src/sync/bucket_access_control.rs
@@ -1,0 +1,146 @@
+use crate::bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl};
+
+/// Operations on [`BucketAccessControl`](BucketAccessControl)s.
+pub struct BucketAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> BucketAccessControlClient<'a> {
+    /// Create a new `BucketAccessControl` using the provided `NewBucketAccessControl`, related to
+    /// the `Bucket` provided by the `bucket_name` argument.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, NewBucketAccessControl};
+    /// use cloud_storage::bucket_access_control::{Role, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let new_bucket_access_control = NewBucketAccessControl {
+    ///     entity: Entity::AllUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// client.bucket_access_control().create("mybucket", &new_bucket_access_control)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        new_bucket_access_control: &NewBucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .create(bucket, new_bucket_access_control),
+        )
+    }
+
+    /// Returns all `BucketAccessControl`s related to this bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::BucketAccessControl;
+    ///
+    /// let client = Client::new()?;
+    /// let acls = client.bucket_access_control().list("mybucket")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self, bucket: &str) -> crate::Result<Vec<BucketAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket_access_control().list(bucket))
+    }
+
+    /// Returns the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<BucketAccessControl> {
+        self.0
+            .runtime
+            .block_on(self.0.client.bucket_access_control().read(bucket, entity))
+    }
+
+    /// Update this `BucketAccessControl`.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut acl = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.bucket_access_control().update(&acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(
+        &self,
+        bucket_access_control: &BucketAccessControl,
+    ) -> crate::Result<BucketAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .update(bucket_access_control),
+        )
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::bucket_access_control::{BucketAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let controls = client.bucket_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// client.bucket_access_control().delete(controls)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket_access_control: BucketAccessControl) -> crate::Result<()> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .bucket_access_control()
+                .delete(bucket_access_control),
+        )
+    }
+}

--- a/src/sync/default_object_access_control.rs
+++ b/src/sync/default_object_access_control.rs
@@ -1,0 +1,155 @@
+use crate::{
+    bucket_access_control::Entity,
+    default_object_access_control::{DefaultObjectAccessControl, NewDefaultObjectAccessControl},
+};
+
+/// Operations on [`DefaultObjectAccessControl`](DefaultObjectAccessControl)s.
+pub struct DefaultObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> DefaultObjectAccessControlClient<'a> {
+    /// Create a new `DefaultObjectAccessControl` entry on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{
+    ///     DefaultObjectAccessControl, NewDefaultObjectAccessControl, Role, Entity,
+    /// };
+    ///
+    /// let client = Client::new()?;
+    /// let new_acl = NewDefaultObjectAccessControl {
+    ///     entity: Entity::AllAuthenticatedUsers,
+    ///     role: Role::Reader,
+    /// };
+    /// let default_acl = client.default_object_access_control().create("mybucket", &new_acl)?;
+    /// # client.default_object_access_control().delete(default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        new_acl: &NewDefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .create(bucket, new_acl),
+        )
+    }
+
+    /// Retrieves default object ACL entries on the specified bucket.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::DefaultObjectAccessControl;
+    ///
+    /// let client = Client::new()?;
+    /// let default_acls = client.default_object_access_control().list("mybucket")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self, bucket: &str) -> crate::Result<Vec<DefaultObjectAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.default_object_access_control().list(bucket))
+    }
+
+    /// Read a single `DefaultObjectAccessControl`.
+    /// The `bucket` argument is the name of the bucket whose `DefaultObjectAccessControl` is to be
+    /// read, and the `entity` argument is the entity holding the permission. Options are
+    /// Can be "user-`userId`", "user-`email_address`", "group-`group_id`", "group-`email_address`",
+    /// "allUsers", or "allAuthenticatedUsers".
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let default_acl = client.default_object_access_control().read("mybucket", &Entity::AllUsers)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, entity: &Entity) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .read(bucket, entity),
+        )
+    }
+
+    /// Update the current `DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers)?;
+    /// default_acl.entity = Entity::AllAuthenticatedUsers;
+    /// client.default_object_access_control().update(&default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(
+        &self,
+        default_object_access_control: &DefaultObjectAccessControl,
+    ) -> crate::Result<DefaultObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .update(default_object_access_control),
+        )
+    }
+
+    /// Delete this 'DefaultObjectAccessControl`.
+    /// ### Important
+    /// Important: This method fails with a `400 Bad Request` response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::default_object_access_control::{DefaultObjectAccessControl, Entity};
+    ///
+    /// let client = Client::new()?;
+    /// let mut default_acl = client.default_object_access_control().read("my_bucket", &Entity::AllUsers)?;
+    /// client.default_object_access_control().delete(default_acl)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(
+        &self,
+        default_object_access_control: DefaultObjectAccessControl,
+    ) -> Result<(), crate::Error> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .default_object_access_control()
+                .delete(default_object_access_control),
+        )
+    }
+}

--- a/src/sync/hmac_key.rs
+++ b/src/sync/hmac_key.rs
@@ -1,0 +1,129 @@
+use crate::hmac_key::{HmacKey, HmacMeta, HmacState};
+
+/// Operations on [`HmacKey`](HmacKey)s.
+pub struct HmacKeyClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> HmacKeyClient<'a> {
+    /// Creates a new HMAC key for the specified service account.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.create` permission for the project in
+    /// which the key will be created.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let hmac_key = client.hmac_key().create()?;
+    /// # use cloud_storage::hmac_key::HmacState;
+    /// # client.hmac_key().update(&hmac_key.metadata.access_id, HmacState::Inactive)?;
+    /// # client.hmac_key().delete(&hmac_key.metadata.access_id)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(&self) -> crate::Result<HmacKey> {
+        self.0.runtime.block_on(self.0.client.hmac_key().create())
+    }
+
+    /// Retrieves a list of HMAC keys matching the criteria. Since the HmacKey is secret, this does
+    /// not return a `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but
+    /// with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.list` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let all_hmac_keys = client.hmac_key().list()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(&self) -> crate::Result<Vec<HmacMeta>> {
+        self.0.runtime.block_on(self.0.client.hmac_key().list())
+    }
+
+    /// Retrieves an HMAC key's metadata. Since the HmacKey is secret, this does not return a
+    /// `HmacKey`, but a `HmacMeta`. This is a redacted version of a `HmacKey`, but with the secret
+    /// data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.get` permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::HmacKey;
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().read("some identifier")?;
+    /// # Ok(())
+    /// # }
+    pub fn read(&self, access_id: &str) -> crate::Result<HmacMeta> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().read(access_id))
+    }
+
+    /// Updates the state of an HMAC key. See the HMAC Key resource descriptor for valid states.
+    /// Since the HmacKey is secret, this does not return a `HmacKey`, but a `HmacMeta`. This is a
+    /// redacted version of a `HmacKey`, but with the secret data omitted.
+    ///
+    /// The authenticated user must have `storage.hmacKeys.update` permission for the project in
+    /// which the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().update("your key", HmacState::Active)?;
+    /// # Ok(())
+    /// # }
+    pub fn update(&self, access_id: &str, state: HmacState) -> crate::Result<HmacMeta> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().update(access_id, state))
+    }
+
+    /// Deletes an HMAC key. Note that a key must be set to `Inactive` first.
+    ///
+    /// The authenticated user must have storage.hmacKeys.delete permission for the project in which
+    /// the key exists.
+    ///
+    /// For general information about HMAC keys in Cloud Storage, see
+    /// [HMAC Keys](https://cloud.google.com/storage/docs/authentication/hmackeys).
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::hmac_key::{HmacKey, HmacState};
+    ///
+    /// let client = Client::new()?;
+    /// let key = client.hmac_key().update("your key", HmacState::Inactive)?; // this is required.
+    /// client.hmac_key().delete(&key.access_id)?;
+    /// # Ok(())
+    /// # }
+    pub fn delete(&self, access_id: &str) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.hmac_key().delete(access_id))
+    }
+}

--- a/src/sync/object.rs
+++ b/src/sync/object.rs
@@ -1,0 +1,273 @@
+use futures::Stream;
+
+use crate::{
+    object::{ComposeRequest, ObjectList},
+    ListRequest, Object,
+};
+
+/// Operations on [`Object`](Object)s.
+pub struct ObjectClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectClient<'a> {
+    /// Create a new object.
+    /// Upload a file as that is loaded in memory to google cloud storage, where it will be
+    /// interpreted according to the mime type you specified.
+    /// ## Example
+    /// ```rust,no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn read_cute_cat(_in: &str) -> Vec<u8> { vec![0, 1] }
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let file: Vec<u8> = read_cute_cat("cat.png");
+    /// let client = Client::new()?;
+    /// client.object().create("cat-photos", file, "recently read cat.png", "image/png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create(
+        &self,
+        bucket: &str,
+        file: Vec<u8>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .create(bucket, file, filename, mime_type),
+        )
+    }
+
+    /// Create a new object. This works in the same way as `ObjectClient::create`, except it does not need
+    /// to load the entire file in ram.
+    pub fn create_streamed<R>(
+        &self,
+        bucket: &str,
+        mut file: R,
+        length: impl Into<Option<u64>>,
+        filename: &str,
+        mime_type: &str,
+    ) -> crate::Result<Object>
+    where
+        R: std::io::Read + Send + 'static,
+    {
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|e| crate::Error::Other(e.to_string()))?;
+
+        let stream = futures::stream::once(async { Ok::<_, crate::Error>(buffer) });
+
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .create_streamed(bucket, stream, length, filename, mime_type),
+        )
+    }
+
+    /// Obtain a list of objects within this Bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::{Object, ListRequest};
+    ///
+    /// let client = Client::new()?;
+    /// let all_objects = client.object().list("my_bucket", ListRequest::default())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn list(
+        &self,
+        bucket: &'a str,
+        list_request: ListRequest,
+    ) -> crate::Result<impl Stream<Item = crate::Result<ObjectList>> + 'a> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().list(bucket, list_request))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let object = client.object().read("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, bucket: &str, file_name: &str) -> crate::Result<Object> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().read(bucket, file_name))
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let bytes = client.object().download("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn download(&self, bucket: &str, file_name: &str) -> crate::Result<Vec<u8>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().download(bucket, file_name))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let mut object = client.object().read("my_bucket", "path/to/my/file.png")?;
+    /// object.content_type = Some("application/xml".to_string());
+    /// client.object().update(&object)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn update(&self, object: &Object) -> crate::Result<Object> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().update(object))
+    }
+
+    /// Deletes a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::Object;
+    ///
+    /// let client = Client::new()?;
+    /// client.object().delete("my_bucket", "path/to/my/file.png")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete(&self, bucket: &str, file_name: &str) -> crate::Result<()> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object().delete(bucket, file_name))
+    }
+
+    /// Obtains a single object with the specified name in the specified bucket.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest, SourceObject};
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().read("my_bucket", "file2")?;
+    /// let compose_request = ComposeRequest {
+    ///     kind: "storage#composeRequest".to_string(),
+    ///     source_objects: vec![
+    ///         SourceObject {
+    ///             name: obj1.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///         SourceObject {
+    ///             name: obj2.name.clone(),
+    ///             generation: None,
+    ///             object_preconditions: None,
+    ///         },
+    ///     ],
+    ///     destination: None,
+    /// };
+    /// let obj3 = client.object().compose("my_bucket", &compose_request, "test-concatted-file")?;
+    /// // obj3 is now a file with the content of obj1 and obj2 concatted together.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn compose(
+        &self,
+        bucket: &str,
+        req: &ComposeRequest,
+        destination_object: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .compose(bucket, req, destination_object),
+        )
+    }
+
+    /// Copy this object to the target bucket and path
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::{Object, ComposeRequest};
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().copy(&obj1, "my_other_bucket", "file2")?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn copy(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .copy(object, destination_bucket, path),
+        )
+    }
+
+    /// Moves a file from the current location to the target bucket and path.
+    ///
+    /// ## Limitations
+    /// This function does not yet support rewriting objects to another
+    /// * Geographical Location,
+    /// * Encryption,
+    /// * Storage class.
+    /// These limitations mean that for now, the rewrite and the copy methods do the same thing.
+    /// ### Example
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::sync::Client;
+    /// use cloud_storage::object::Object;
+    ///
+    /// let client = Client::new()?;
+    /// let obj1 = client.object().read("my_bucket", "file1")?;
+    /// let obj2 = client.object().rewrite(&obj1, "my_other_bucket", "file2")?;
+    /// // obj2 is now a copy of obj1.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn rewrite(
+        &self,
+        object: &Object,
+        destination_bucket: &str,
+        path: &str,
+    ) -> crate::Result<Object> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object()
+                .rewrite(object, destination_bucket, path),
+        )
+    }
+}

--- a/src/sync/object_access_control.rs
+++ b/src/sync/object_access_control.rs
@@ -1,0 +1,95 @@
+use crate::{
+    bucket_access_control::Entity,
+    object_access_control::{NewObjectAccessControl, ObjectAccessControl},
+};
+
+/// Operations on [`ObjectAccessControl`](ObjectAccessControl)s.
+pub struct ObjectAccessControlClient<'a>(pub(super) &'a super::Client);
+
+impl<'a> ObjectAccessControlClient<'a> {
+    /// Creates a new ACL entry on the specified `object`.
+    ///
+    /// ### Important
+    /// This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn create(
+        &self,
+        bucket: &str,
+        object: &str,
+        new_object_access_control: &NewObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object_access_control().create(
+                bucket,
+                object,
+                new_object_access_control,
+            ))
+    }
+
+    /// Retrieves `ACL` entries on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn list(&self, bucket: &str, object: &str) -> crate::Result<Vec<ObjectAccessControl>> {
+        self.0
+            .runtime
+            .block_on(self.0.client.object_access_control().list(bucket, object))
+    }
+
+    /// Returns the `ACL` entry for the specified entity on the specified bucket.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn read(
+        &self,
+        bucket: &str,
+        object: &str,
+        entity: &Entity,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .read(bucket, object, entity),
+        )
+    }
+
+    /// Updates an ACL entry on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn update(
+        &self,
+        object_access_control: &ObjectAccessControl,
+    ) -> crate::Result<ObjectAccessControl> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .update(object_access_control),
+        )
+    }
+
+    /// Permanently deletes the ACL entry for the specified entity on the specified object.
+    ///
+    /// ### Important
+    /// Important: This method fails with a 400 Bad Request response for buckets with uniform
+    /// bucket-level access enabled. Use `Bucket::get_iam_policy` and `Bucket::set_iam_policy` to
+    /// control access instead.
+    pub fn delete(&self, object_access_control: ObjectAccessControl) -> crate::Result<()> {
+        self.0.runtime.block_on(
+            self.0
+                .client
+                .object_access_control()
+                .delete(object_access_control),
+        )
+    }
+}


### PR DESCRIPTION
Only moving the bucket access control functions right now.

I wanted to open this early to get some feedback from you on how you feel about this API. I'm leaving the existing functions / globals behind in order to do this piecemeal, but I'd expect you could remove those immediately afterward or after an intermediate release to allow people to upgrade.

I'll continue on this path in the hopes that it looks acceptable, but please let me know if you have any concerns or questions!