### PR TITLE
Fix for stdout noise

### DIFF
--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -416,7 +416,7 @@ impl Object {
             fn req_mut(&mut self) -> Option<&mut ListRequest> {
                 match self {
                     Start(ref mut req) | HasMore(ref mut req) => Some(req),
-                    Done => return None,
+                    Done => None,
                 }
             }
         }
@@ -424,7 +424,6 @@ impl Object {
         Ok(stream::unfold(
             ListState::Start(list_request),
             move |mut state| async move {
-                println!("reached");
                 let url = format!("{}/b/{}/o", crate::BASE_URL, percent_encode(bucket));
                 let headers = match crate::get_headers().await {
                     Ok(h) => h,
@@ -550,11 +549,11 @@ impl Object {
             percent_encode(bucket),
             percent_encode(file_name),
         );
-        let resp = dbg!(crate::CLIENT
+        let resp = crate::CLIENT
             .get(&url)
             .headers(crate::get_headers().await?)
             .send()
-            .await?);
+            .await?;
         if resp.status() == StatusCode::NOT_FOUND {
             Err(Error::Other(resp.text().await?))
         } else {


### PR DESCRIPTION
A simple fix for https://github.com/ThouCheese/cloud-storage-rs/issues/67 that removes `println!` output.