### PR TITLE
[Clippy, small nitpick] 'clippy --all-targets' found an inconsistent struct member order initialization.

### DIFF
--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -1487,7 +1487,7 @@ pub struct SizedByteStream<S: Stream<Item = crate::Result<u8>> + Unpin> {
 
 impl<S: Stream<Item = crate::Result<u8>> + Unpin> SizedByteStream<S> {
     pub(crate) fn new(bytes: S, size: Option<u64>) -> Self {
-        Self { bytes, size }
+        Self { size, bytes }
     }
 }
 


### PR DESCRIPTION
Its a nitpick of the worst kind, sorry.
If anything, it makes clippy happier.