### PR TITLE
Updated the GCS URLs to be storage.googleapis.com.

### DIFF
--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -7,6 +7,9 @@ use crate::{
     ListRequest, Object,
 };
 
+// Object uploads has its own url for some reason
+const BASE_URL: &str = "https://storage.googleapis.com/upload/storage/v1/b";
+
 /// Operations on [`Object`](Object)s.
 #[derive(Debug)]
 pub struct ObjectClient<'a>(pub(super) &'a super::Client);
@@ -38,8 +41,6 @@ impl<'a> ObjectClient<'a> {
     ) -> crate::Result<Object> {
         use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 
-        // has its own url for some reason
-        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
         let url = &format!(
             "{}/{}/o?uploadType=media&name={}",
             BASE_URL,
@@ -98,8 +99,6 @@ impl<'a> ObjectClient<'a> {
     {
         use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 
-        // has its own url for some reason
-        const BASE_URL: &str = "https://www.googleapis.com/upload/storage/v1/b";
         let url = &format!(
             "{}/{}/o?uploadType=media&name={}",
             BASE_URL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ lazy_static::lazy_static! {
 /// A type alias where the error is set to be `cloud_storage::Error`.
 pub type Result<T> = std::result::Result<T, crate::Error>;
 
-const BASE_URL: &str = "https://www.googleapis.com/storage/v1";
+const BASE_URL: &str = "https://storage.googleapis.com/storage/v1";
 
 fn from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
 where


### PR DESCRIPTION
The www.googleapis.com endpoint is still supported for the JSON API, but storage.googleapis.com is the preferred endpoint for better performance and availability.