### PR TITLE
Replace futures crate with futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ pem =              { version = "0.8",  default-features = false, optional = true
 chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
 hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
 tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
-futures =          { version = "0.3",  default_features = false, features = ["alloc"] }
+futures-util =     { version = "0.3",  default_features = false, features = ["alloc"] }
 bytes =            { version = "1.0",  default-features = false }
 async-trait =      { version = "0.1.48", default-features = false }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ impl Default for Client {
 impl Client {
     /// Constructs a client with the default token provider, where it attemps to obtain the
     /// credentials from the following locations:
-    /// 
+    ///
     /// 1. Checks for the environment variable `SERVICE_ACCOUNT`, and if it exists, reads the file
     /// at the path specified there as a credentials json file.
     /// 2. It attemps to do the same with the `GOOGLE_APPLICATION_CREDENTIALS` var.

--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -1,4 +1,4 @@
-use futures::{stream, Stream, TryStream};
+use futures_util::{stream, Stream, TryStream};
 use reqwest::StatusCode;
 
 use crate::{
@@ -322,7 +322,7 @@ impl<'a> ObjectClient<'a> {
         bucket: &str,
         file_name: &str,
     ) -> crate::Result<impl Stream<Item = crate::Result<u8>> + Unpin> {
-        use futures::{StreamExt, TryStreamExt};
+        use futures_util::{StreamExt, TryStreamExt};
         let url = format!(
             "{}/b/{}/o/{}?alt=media",
             crate::BASE_URL,
@@ -340,7 +340,7 @@ impl<'a> ObjectClient<'a> {
         let size = response.content_length();
         let bytes = response
             .bytes_stream()
-            .map(|chunk| chunk.map(|c| futures::stream::iter(c.into_iter().map(Ok))))
+            .map(|chunk| chunk.map(|c| futures_util::stream::iter(c.into_iter().map(Ok))))
             .try_flatten();
         Ok(SizedByteStream::new(bytes, size))
     }
@@ -565,7 +565,7 @@ impl<'a> ObjectClient<'a> {
         );
         let mut headers = self.0.get_headers().await?;
         headers.insert(CONTENT_LENGTH, "0".parse()?);
-        let s =  self
+        let s = self
             .0
             .client
             .post(&url)
@@ -578,8 +578,8 @@ impl<'a> ObjectClient<'a> {
         let result: RewriteResponse = serde_json::from_str(dbg!(&s)).unwrap();
         Ok(result.resource)
         // match result {
-            // GoogleResponse::Success(s) => Ok(s.resource),
-            // GoogleResponse::Error(e) => Err(e.into()),
+        // GoogleResponse::Success(s) => Ok(s.resource),
+        // GoogleResponse::Error(e) => Err(e.into()),
         // }
     }
 }

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -1,8 +1,8 @@
 pub use crate::resources::bucket::Owner;
 use crate::resources::object_access_control::ObjectAccessControl;
-use futures::Stream;
+use futures_util::Stream;
 #[cfg(feature = "global-client")]
-use futures::TryStream;
+use futures_util::TryStream;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use std::collections::HashMap;
 
@@ -331,7 +331,7 @@ impl Object {
         file.read_to_end(&mut buffer)
             .map_err(|e| crate::Error::Other(e.to_string()))?;
 
-        let stream = futures::stream::once(async { Ok::<_, crate::Error>(buffer) });
+        let stream = futures_util::stream::once(async { Ok::<_, crate::Error>(buffer) });
 
         crate::runtime()?.block_on(Self::create_streamed(
             bucket, stream, length, filename, mime_type,
@@ -369,7 +369,7 @@ impl Object {
     /// This function requires that the feature flag `sync` is enabled in `Cargo.toml`.
     #[cfg(all(feature = "global-client", feature = "sync"))]
     pub fn list_sync(bucket: &str, list_request: ListRequest) -> crate::Result<Vec<ObjectList>> {
-        use futures::TryStreamExt;
+        use futures_util::TryStreamExt;
 
         let rt = crate::runtime()?;
         let listed = rt.block_on(Self::list(bucket, list_request))?;
@@ -971,7 +971,7 @@ pub(crate) fn percent_encode(input: &str) -> String {
 mod tests {
     use super::*;
     use crate::Error;
-    use futures::{stream, StreamExt, TryStreamExt};
+    use futures_util::{stream, StreamExt, TryStreamExt};
 
     #[tokio::test]
     async fn create() -> Result<(), Box<dyn std::error::Error>> {
@@ -1548,9 +1548,9 @@ impl<S: Stream<Item = crate::Result<u8>> + Unpin> Stream for SizedByteStream<S> 
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
-        cx: &mut futures::task::Context,
-    ) -> futures::task::Poll<Option<Self::Item>> {
-        futures::StreamExt::poll_next_unpin(&mut self.bytes, cx)
+        cx: &mut std::task::Context,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        futures_util::StreamExt::poll_next_unpin(&mut self.bytes, cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -26,7 +26,7 @@ pub struct Client {
 impl Client {
     /// Constructs a client with the default token provider, where it attemps to obtain the
     /// credentials from the following locations:
-    /// 
+    ///
     /// 1. Checks for the environment variable `SERVICE_ACCOUNT`, and if it exists, reads the file
     /// at the path specified there as a credentials json file.
     /// 2. It attemps to do the same with the `GOOGLE_APPLICATION_CREDENTIALS` var.

--- a/src/sync/bucket_access_control.rs
+++ b/src/sync/bucket_access_control.rs
@@ -1,6 +1,4 @@
-use crate::{
-    bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl},
-};
+use crate::bucket_access_control::{BucketAccessControl, Entity, NewBucketAccessControl};
 
 /// Operations on [`BucketAccessControl`](BucketAccessControl)s.
 #[derive(Debug)]

--- a/src/sync/helpers/reader_stream.rs
+++ b/src/sync/helpers/reader_stream.rs
@@ -1,4 +1,4 @@
-use futures::Stream;
+use futures_util::Stream;
 use std::{
     io::{BufReader, Read},
     pin::Pin,

--- a/src/sync/hmac_key.rs
+++ b/src/sync/hmac_key.rs
@@ -1,6 +1,4 @@
-use crate::{
-    hmac_key::{HmacKey, HmacMeta, HmacState},
-};
+use crate::hmac_key::{HmacKey, HmacMeta, HmacState};
 
 /// Operations on [`HmacKey`](HmacKey)s.
 #[derive(Debug)]

--- a/src/sync/object.rs
+++ b/src/sync/object.rs
@@ -2,7 +2,7 @@ use crate::{
     object::{ComposeRequest, ObjectList},
     ListRequest, Object,
 };
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 
 /// Operations on [`Object`](Object)s.
 #[derive(Debug)]


### PR DESCRIPTION
`futures` depends on a lot of unnecessary stuff. This replaces it with `futures-util`, which contains a subset of the `futures` crate features
