### PR TITLE
Fix token lifetime bug

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -17,7 +17,7 @@ pub trait TokenCache: Sync {
     /// the token.
     async fn get(&self, client: &reqwest::Client) -> crate::Result<String> {
         match self.token_and_exp().await {
-            Some((token, exp)) if now() > exp => Ok(token),
+            Some((token, exp)) if now() < exp => Ok(token),
             _ => {
                 let (token, exp) = self.fetch_token(client).await?;
                 self.set_token(token, exp).await?;

--- a/src/token.rs
+++ b/src/token.rs
@@ -17,7 +17,7 @@ pub trait TokenCache: Sync {
     /// the token.
     async fn get(&self, client: &reqwest::Client) -> crate::Result<String> {
         match self.token_and_exp().await {
-            Some((token, exp)) if now() < exp => Ok(token),
+            Some((token, exp)) if now() + 300 < exp => Ok(token),
             _ => {
                 let (token, exp) = self.fetch_token(client).await?;
                 self.set_token(token, exp).await?;


### PR DESCRIPTION
Hi!

I noticed that a new token is created for every request. Also, if no request was being made for more than 1 hour, error 401 unauthorized was returned by google.

Found the issue in the token cache struct. Tested it quickly in my own environment, and it seems to be working now.