### PR TITLE
Support single-request multipart upload for setting metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 trust-dns = ["reqwest/trust-dns"]
 
 [dependencies]
-reqwest =          { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest =          { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
 percent-encoding = { version = "2",    default-features = false }
 jsonwebtoken =     { version = "7",    default-features = false }
 serde =            { version = "1",    default-features = false, features = ["derive"] }


### PR DESCRIPTION
@ThouCheese Hi could you take a look at this PR and suggest any edits etc? This resolves [this issue ](https://github.com/ThouCheese/cloud-storage-rs/issues/84).

I've added tests and verified that the tests are passing for both the async and the sync version. Thanks!