### PR TITLE
Fix example for `download_streamed`

### DIFF
--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -314,6 +314,7 @@ impl<'a> ObjectClient<'a> {
     /// while let Some(byte) = stream.next().await {
     ///     file.write_all(&[byte.unwrap()]).await.unwrap();
     /// }
+    /// file.flush().await?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
If you don't flush the buffer the end of the file might not save