### PR TITLE
Remove chrono dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ trust-dns = ["reqwest/trust-dns"]
 [dependencies]
 reqwest =          { version = "0.11", default-features = false, features = ["json", "stream"] }
 percent-encoding = { version = "2",    default-features = false }
-jsonwebtoken =     { version = "7",    default-features = false }
+jsonwebtoken =     { version = "8.1",  default-features = false, features = ["use_pem"] }
 serde =            { version = "1",    default-features = false, features = ["derive"] }
 serde_json =       { version = "1",    default-features = false }
 base64 =           { version = "0.13", default-features = false }
@@ -34,7 +34,7 @@ dotenv =           { version = "0.15", default-features = false }
 openssl =          { version = "0.10", default-features = false, optional = true }
 ring =             { version = "0.16", default-features = false, optional = true }
 pem =              { version = "0.8",  default-features = false, optional = true }
-chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
+time =             { version = "0.3",  default-features = false, features = ["serde-well-known", "serde-human-readable", "macros"]}
 hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
 tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
 futures-util =     { version = "0.3",  default_features = false, features = ["alloc"] }

--- a/src/client/bucket.rs
+++ b/src/client/bucket.rs
@@ -150,7 +150,7 @@ impl<'a> BucketClient<'a> {
     /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3").await?;
     /// bucket.retention_policy = Some(RetentionPolicy {
     ///     retention_period: 50,
-    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     effective_time: time::OffsetDateTime::now_utc() + std::time::Duration::from_secs(50),
     ///     is_locked: Some(false),
     /// });
     /// client.bucket().update(&bucket).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,9 @@ pub type Result<T> = std::result::Result<T, crate::Error>;
 
 const BASE_URL: &str = "https://storage.googleapis.com/storage/v1";
 
+const ISO_8601_BASIC_FORMAT: &[::time::format_description::FormatItem<'_>] = time::macros::format_description!("[year][month][day]T[hour][minute][second]Z");
+time::serde::format_description!(rfc3339_date, Date, "[year]-[month]-[day]");
+
 fn from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
 where
     T: std::str::FromStr,

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -30,9 +30,11 @@ pub struct Bucket {
     /// The name of the bucket.
     pub name: String,
     /// The creation time of the bucket in RFC 3339 format.
-    pub time_created: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub time_created: time::OffsetDateTime,
     /// The modification time of the bucket in RFC 3339 format.
-    pub updated: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated: time::OffsetDateTime,
     /// Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.
     pub default_event_based_hold: Option<bool>,
     /// The bucket's retention policy, which defines the minimum age an object in the bucket must
@@ -147,7 +149,8 @@ pub struct RetentionPolicy {
     #[serde(deserialize_with = "crate::from_str")]
     pub retention_period: u64,
     /// The time from which the retentionPolicy was effective, in RFC 3339 format.
-    pub effective_time: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub effective_time: time::OffsetDateTime,
     /// Whether or not the retentionPolicy is locked. If true, the retentionPolicy cannot be removed
     /// and the retention period cannot be reduced.
     pub is_locked: Option<bool>,
@@ -177,7 +180,8 @@ pub struct UniformBucketLevelAccess {
     ///
     /// iamConfiguration.uniformBucketLevelAccess.enabled may be changed from true to false until
     /// the locked time, after which the field is immutable.
-    pub locked_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub locked_time: Option<time::OffsetDateTime>,
 }
 
 /// Contains information about the encryption used for data in this Bucket.
@@ -297,7 +301,8 @@ pub struct Condition {
     /// A date in `RFC 3339` format with only the date part (for instance, "2013-01-15"). This
     /// condition is satisfied when an object is created before midnight of the specified date in
     /// UTC.
-    pub created_before: Option<chrono::NaiveDate>,
+    #[serde(with = "crate::rfc3339_date::option")]
+    pub created_before: Option<time::Date>,
     /// Relevant only for versioned objects. If the value is true, this condition matches the live
     /// version of objects; if the value is `false`, it matches noncurrent versions of objects.
     pub is_live: Option<bool>,
@@ -649,7 +654,7 @@ impl Bucket {
     /// let mut bucket = Bucket::read("cloud-storage-rs-doc-3").await?;
     /// bucket.retention_policy = Some(RetentionPolicy {
     ///     retention_period: 50,
-    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     effective_time: time::OffsetDateTime::now_utc() + std::time::Duration::from_secs(50),
     ///     is_locked: Some(false),
     /// });
     /// bucket.update().await?;
@@ -862,7 +867,7 @@ mod tests {
         let mut bucket = crate::create_test_bucket("test-update").await;
         bucket.retention_policy = Some(RetentionPolicy {
             retention_period: 50,
-            effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+            effective_time: time::OffsetDateTime::now_utc() + std::time::Duration::from_secs(50),
             is_locked: Some(false),
         });
         bucket.update().await?;
@@ -968,7 +973,7 @@ mod tests {
             let mut bucket = crate::create_test_bucket_sync("test-update");
             bucket.retention_policy = Some(RetentionPolicy {
                 retention_period: 50,
-                effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+                effective_time: time::OffsetDateTime::now_utc() + std::time::Duration::from_secs(50),
                 is_locked: Some(false),
             });
             bucket.update_sync()?;

--- a/src/resources/hmac_key.rs
+++ b/src/resources/hmac_key.rs
@@ -39,9 +39,11 @@ pub struct HmacMeta {
     /// The state of the key.
     pub state: HmacState,
     /// The creation time of the HMAC key.
-    pub time_created: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub time_created: time::OffsetDateTime,
     /// The last modification time of the HMAC key metadata.
-    pub updated: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated: time::OffsetDateTime,
     /// HTTP 1.1 Entity tag for the HMAC key.
     pub etag: String,
 }

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -32,24 +32,29 @@ pub struct Object {
     /// as application/octet-stream.
     pub content_type: Option<String>,
     /// The creation time of the object in RFC 3339 format.
-    pub time_created: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub time_created: time::OffsetDateTime,
     /// The modification time of the object metadata in RFC 3339 format.
-    pub updated: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated: time::OffsetDateTime,
     /// The deletion time of the object in RFC 3339 format. Returned if and only if this version of
     /// the object is no longer a live version, but remains in the bucket as a noncurrent version.
-    pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub time_deleted: Option<time::OffsetDateTime>,
     /// Whether or not the object is subject to a temporary hold.
     pub temporary_hold: Option<bool>,
     /// Whether or not the object is subject to an event-based hold.
     pub event_based_hold: Option<bool>,
     /// The earliest time that the object can be deleted, based on a bucket's retention policy, in
     /// RFC 3339 format.
-    pub retention_expiration_time: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub retention_expiration_time: Option<time::OffsetDateTime>,
     /// Storage class of the object.
     pub storage_class: String,
     /// The time at which the object's storage class was last changed. When the object is initially
     /// created, it will be set to timeCreated.
-    pub time_storage_class_updated: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub time_storage_class_updated: time::OffsetDateTime,
     /// Content-Length of the data in bytes.
     #[serde(deserialize_with = "crate::from_str")]
     pub size: u64,
@@ -782,7 +787,7 @@ impl Object {
             .join(";");
 
         // 1 construct the canonical request
-        let issue_date = chrono::Utc::now();
+        let issue_date = time::OffsetDateTime::now_utc();
         let file_path = self.path_to_resource(file_path);
         let query_string = Self::get_canonical_query_string(
             &issue_date,
@@ -808,7 +813,7 @@ impl Object {
             {credential_scope}\n\
             {hashed_canonical_request}",
             signing_algorithm = "GOOG4-RSA-SHA256",
-            current_datetime = issue_date.format("%Y%m%dT%H%M%SZ"),
+            current_datetime = issue_date.format(crate::ISO_8601_BASIC_FORMAT).unwrap(),
             credential_scope = Self::get_credential_scope(&issue_date),
             hashed_canonical_request = hex_hash,
         );
@@ -855,7 +860,7 @@ impl Object {
 
     #[inline(always)]
     fn get_canonical_query_string(
-        date: &chrono::DateTime<chrono::Utc>,
+        date: &time::OffsetDateTime,
         exp: u32,
         headers: &str,
         content_disposition: Option<String>,
@@ -873,7 +878,7 @@ impl Object {
             X-Goog-SignedHeaders={signed}",
             algo = "GOOG4-RSA-SHA256",
             cred = percent_encode(&credential),
-            date = date.format("%Y%m%dT%H%M%SZ"),
+            date = date.format(crate::ISO_8601_BASIC_FORMAT).unwrap(),
             exp = exp,
             signed = percent_encode(headers),
         );
@@ -893,8 +898,8 @@ impl Object {
     }
 
     #[inline(always)]
-    fn get_credential_scope(date: &chrono::DateTime<chrono::Utc>) -> String {
-        format!("{}/henk/storage/goog4_request", date.format("%Y%m%d"))
+    fn get_credential_scope(date: &time::OffsetDateTime) -> String {
+        format!("{}/henk/storage/goog4_request", date.format(time::macros::format_description!("[year][month][day]")).unwrap())
     }
 }
 

--- a/src/sync/bucket.rs
+++ b/src/sync/bucket.rs
@@ -99,7 +99,7 @@ impl<'a> BucketClient<'a> {
     /// let mut bucket = client.bucket().read("cloud-storage-rs-doc-3")?;
     /// bucket.retention_policy = Some(RetentionPolicy {
     ///     retention_period: 50,
-    ///     effective_time: chrono::Utc::now() + chrono::Duration::seconds(50),
+    ///     effective_time: time::OffsetDateTime::now_utc() + std::time::Duration::from_secs(50),
     ///     is_locked: Some(false),
     /// });
     /// client.bucket().update(&bucket)?;


### PR DESCRIPTION
Replace chrono with time, to avoid RUSTSEC-2020-0159 notifications produced by e.g. `cargo audit` in applications using this code. This is a breaking change.