### PR TITLE
Updated/corrected documentation on ObjectClient methods

### DIFF
--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -349,7 +349,7 @@ impl<'a> ObjectClient<'a> {
     /// information in `object`.
     ///
     /// Note that if the `name` or `bucket` fields are changed, the object will not be found.
-    /// See [`rewrite`], [`copy`], or [`rename`] for similar operations.
+    /// See [`rewrite`] or [`copy`] for similar operations.
     /// ### Example
     /// ```no_run
     /// # #[tokio::main]

--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -345,7 +345,11 @@ impl<'a> ObjectClient<'a> {
         Ok(SizedByteStream::new(bytes, size))
     }
 
-    /// Obtains a single object with the specified name in the specified bucket.
+    /// Updates a single object with the specified name in the specified bucket with the new
+    /// information in `object`.
+    ///
+    /// Note that if the `name` or `bucket` fields are changed, the object will not be found.
+    /// See [`rewrite`], [`copy`], or [`rename`] for similar operations.
     /// ### Example
     /// ```no_run
     /// # #[tokio::main]
@@ -417,7 +421,7 @@ impl<'a> ObjectClient<'a> {
         }
     }
 
-    /// Obtains a single object with the specified name in the specified bucket.
+    /// Concatenates the contents of multiple objects into one.
     /// ### Example
     /// ```no_run
     /// # #[tokio::main]
@@ -477,7 +481,7 @@ impl<'a> ObjectClient<'a> {
         }
     }
 
-    /// Copy this object to the target bucket and path
+    /// Copy this object to the target bucket and path.
     /// ### Example
     /// ```no_run
     /// # #[tokio::main]
@@ -575,7 +579,7 @@ impl<'a> ObjectClient<'a> {
             .text()
             .await?;
 
-        let result: RewriteResponse = serde_json::from_str(dbg!(&s)).unwrap();
+        let result: RewriteResponse = serde_json::from_str(&s).unwrap();
         Ok(result.resource)
         // match result {
         // GoogleResponse::Success(s) => Ok(s.resource),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = Client::default();
 //! let mut object = client.object().read("mybucket", "myfile").await?;
-//! object.name = "mybetterfile".to_string();
+//! object.content_type = Some("application/xml".to_string());
 //! client.object().update(&object).await?;
 //! # Ok(())
 //! # }


### PR DESCRIPTION
Closes #109 .

* Updated documentation on `update` and `compose` methods.
* Removed `dbg` left in `rewrite`.
* Replaced erroneous example in module docs.
