### PR TITLE
download a stream of bytes, not single byte

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@ mod error;
 mod resources;
 mod token;
 
+/// re-exported type that appears in public api
+pub use bytes::Bytes;
+
 use crate::resources::service_account::ServiceAccount;
 pub use crate::{
     client::Client,

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -449,13 +449,45 @@ impl Object {
     /// # }
     /// ```
     #[cfg(feature = "global-client")]
+    #[deprecated = "Streaming u8 is inefficient, use download_bytes_stream instead"]
     pub async fn download_streamed(
         bucket: &str,
         file_name: &str,
     ) -> crate::Result<impl Stream<Item = crate::Result<u8>> + Unpin> {
+        #[allow(deprecated)] // this calling function is deprecated as well
         crate::CLOUD_CLIENT
             .object()
             .download_streamed(bucket, file_name)
+            .await
+    }
+
+    /// Download the content of the object with the specified name in the specified bucket, without
+    /// allocating the whole file into a vector.
+    /// ### Example
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_storage::Object;
+    /// use futures_util::stream::StreamExt;
+    /// use std::fs::File;
+    /// use std::io::{BufWriter, Write};
+    ///
+    /// let mut stream = Object::download_bytes_stream("my_bucket", "path/to/my/file.png").await?;
+    /// let mut file = BufWriter::new(File::create("file.png")?);
+    /// while let Some(bytes) = stream.next().await {
+    ///     file.write_all(&bytes?)?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "global-client")]
+    pub async fn download_bytes_stream(
+        bucket: &str,
+        file_name: &str,
+    ) -> crate::Result<impl Stream<Item = crate::Result<crate::Bytes>> + Unpin> {
+        crate::CLOUD_CLIENT
+            .object()
+            .download_bytes_stream(bucket, file_name)
             .await
     }
 


### PR DESCRIPTION
Hi!

I noticed that fact that your download_streaming APIs return an `impl Stream<Item = crate::Result<u8>>` which is very inefficient. `create::Result<u8>` has size 72 on my machine (64bit arm), so for every byte copied, we need to pass 72 bytes around. But even if it was `impl Stream<Item = u8>`, it would still be inefficient. Such streams always work on slices of bytes (e.g. see the Read or AsyncRead traits) or here, it's the easiest and most idiomatic to just return a stream of `Bytes`.

So I deprecated `download_streamed` and added `download_bytes_stream`.

Hope you like it :)

Cheers,
Kosta