### PR TITLE
Updated versions. No Cargo audit vulnerabilities anymore.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cloud-storage"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Luuk Wester <luuk.wester@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A crate for uploading files to Google cloud storage, and for generating download urls."
 license = "MIT"
 repository = "https://github.com/ThouCheese/cloud-storage-rs"
 documentation = "https://docs.rs/cloud-storage"
-keywords = ["google", "cloud", "storage"]
+keywords = ["google", "cloud", "storage", "rust"]
 readme = "README.md"
 categories = ["api-bindings", "web-programming"]
 resolver = "2"
@@ -23,26 +23,26 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 trust-dns = ["reqwest/trust-dns"]
 
 [dependencies]
-reqwest =          { version = "0.11", default-features = false, features = ["json", "stream"] }
-percent-encoding = { version = "2",    default-features = false }
-jsonwebtoken =     { version = "7",    default-features = false }
-serde =            { version = "1",    default-features = false, features = ["derive"] }
-serde_json =       { version = "1",    default-features = false }
-base64 =           { version = "0.13", default-features = false }
-lazy_static =      { version = "1",    default-features = false }
-dotenv =           { version = "0.15", default-features = false }
-openssl =          { version = "0.10", default-features = false, optional = true }
-ring =             { version = "0.16", default-features = false, optional = true }
-pem =              { version = "0.8",  default-features = false, optional = true }
-chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
-hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
-tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
-futures-util =     { version = "0.3",  default_features = false, features = ["alloc"] }
-bytes =            { version = "1.0",  default-features = false }
-async-trait =      { version = "0.1.48", default-features = false }
+reqwest =          { version = "0.11",   default-features = false, features = ["json", "stream"] }
+percent-encoding = { version = "2",      default-features = false }
+jsonwebtoken =     { version = "8",      default-features = false, features = ["use_pem"] }
+serde =            { version = "1",      default-features = false, features = ["derive"] }
+serde_json =       { version = "1",      default-features = false }
+base64 =           { version = "0.21",   default-features = false }
+lazy_static =      { version = "1",      default-features = false }
+dotenvy =          { version = "0.15",   default-features = false }
+openssl =          { version = "0.10",   default-features = false, optional = true }
+ring =             { version = "0.16",   default-features = false, optional = true }
+pem =              { version = "3.0",    default-features = false, optional = true }
+chrono =           { version = "0.4",    default-features = false, features = ["serde", "clock"] }
+hex =              { version = "0.4",    default-features = false, features = ["alloc"] }
+tokio =            { version = "1",      default-features = false, features = ["macros", "rt"] }
+futures-util =     { version = "0.3",    default_features = false, features = ["alloc"] }
+bytes =            { version = "1.4",    default-features = false }
+async-trait =      { version = "0.1.73", default-features = false }
 
 [dev-dependencies]
-tokio =            { version = "1.0",  default-features = false, features = ["full"] }
+tokio =            { version = "1",  default-features = false, features = ["full"] }
 
 [package.metadata.docs.rs]
 features = ["global-client", "sync"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library that can be used to push blobs to [Google Cloud Storage](https://cloud
 Add the following line to your Cargo.toml
 ```toml
 [dependencies]
-cloud-storage = "0.10"
+cloud-storage = "0.11"
 ```
 ### Examples
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ fn read_test_bucket_sync() -> Bucket {
 
 #[cfg(all(test, feature = "global-client"))]
 async fn read_test_bucket() -> Bucket {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let name = std::env::var("TEST_BUCKET").unwrap();
     match Bucket::read(&name).await {
         Ok(bucket) => bucket,
@@ -197,7 +197,7 @@ fn create_test_bucket_sync(name: &str) -> Bucket {
 async fn create_test_bucket(name: &str) -> Bucket {
     std::thread::sleep(std::time::Duration::from_millis(1500)); // avoid getting rate limited
 
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let base_name = std::env::var("TEST_BUCKET").unwrap();
     let name = format!("{}-{}", base_name, name);
     let new_bucket = NewBucket {

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -827,7 +827,7 @@ mod tests {
 
     #[tokio::test]
     async fn create() -> Result<(), Box<dyn std::error::Error>> {
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
         let base_name = std::env::var("TEST_BUCKET")?;
         // use a more complex bucket in this test.
         let new_bucket = NewBucket {
@@ -923,7 +923,7 @@ mod tests {
 
         #[test]
         fn create() -> Result<(), Box<dyn std::error::Error>> {
-            dotenv::dotenv().ok();
+            dotenvy::dotenv().ok();
             let base_name = std::env::var("TEST_BUCKET")?;
             // use a more complex bucket in this test.
             let new_bucket = NewBucket {

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -929,7 +929,7 @@ mod ring {
         };
 
         let key_pem = pem::parse(crate::SERVICE_ACCOUNT.private_key.as_bytes())?;
-        let key = RsaKeyPair::from_pkcs8(&key_pem.contents)?;
+        let key = RsaKeyPair::from_pkcs8(&key_pem.contents())?;
         let rng = SystemRandom::new();
         let mut signature = vec![0; key.public_modulus_len()];
         key.sign(&RSA_PKCS1_SHA256, &rng, message.as_bytes(), &mut signature)?;

--- a/src/resources/service_account.rs
+++ b/src/resources/service_account.rs
@@ -1,3 +1,5 @@
+use dotenvy::dotenv;
+
 /// A deserialized `service-account-********.json`-file.
 #[derive(serde::Deserialize, Debug)]
 pub struct ServiceAccount {
@@ -26,7 +28,7 @@ pub struct ServiceAccount {
 
 impl ServiceAccount {
     pub(crate) fn get() -> Self {
-        dotenv::dotenv().ok();
+        dotenv().ok();
         let credentials_json = std::env::var("SERVICE_ACCOUNT")
             .or_else(|_| std::env::var("GOOGLE_APPLICATION_CREDENTIALS"))
             .map(|path| std::fs::read_to_string(path).expect("SERVICE_ACCOUNT file not found"))


### PR DESCRIPTION
```
% cargo audit                                                                                                                                                     
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 561 security advisories (from ~/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (182 crate dependencies)
```

Additionally moved from unmaintained `dotenv` to `dotenvy`