### PR TITLE
feat(wasm): added wasm support

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/cloud-storage-rs.iml
+++ b/.idea/cloud-storage-rs.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/cloud-storage-rs.iml" filepath="$PROJECT_DIR$/.idea/cloud-storage-rs.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-storage"
-version = "0.11.3"
+version = "0.11.1"
 authors = ["Luuk Wester <luuk.wester@gmail.com>"]
 edition = "2018"
 description = "A crate for uploading files to Google cloud storage, and for generating download urls."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-storage"
-version = "0.11.1"
+version = "0.11.3"
 authors = ["Luuk Wester <luuk.wester@gmail.com>"]
 edition = "2018"
 description = "A crate for uploading files to Google cloud storage, and for generating download urls."
@@ -23,26 +23,38 @@ rustls-tls = ["reqwest/rustls-tls", "ring", "pem"]
 trust-dns = ["reqwest/trust-dns"]
 
 [dependencies]
-reqwest =          { version = "0.11", default-features = false, features = ["json", "stream"] }
-percent-encoding = { version = "2",    default-features = false }
-jsonwebtoken =     { version = "7",    default-features = false }
-serde =            { version = "1",    default-features = false, features = ["derive"] }
-serde_json =       { version = "1",    default-features = false }
-base64 =           { version = "0.13", default-features = false }
-lazy_static =      { version = "1",    default-features = false }
-dotenv =           { version = "0.15", default-features = false }
-openssl =          { version = "0.10", default-features = false, optional = true }
-ring =             { version = "0.16", default-features = false, optional = true }
-pem =              { version = "0.8",  default-features = false, optional = true }
-chrono =           { version = "0.4",  default-features = false, features = ["serde"] }
-hex =              { version = "0.4",  default-features = false, features = ["alloc"] }
-tokio =            { version = "1.0",  default-features = false, features = ["macros", "rt"] }
-futures-util =     { version = "0.3",  default_features = false, features = ["alloc"] }
-bytes =            { version = "1.0",  default-features = false }
-async-trait =      { version = "0.1.48", default-features = false }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "stream"] }
+
+percent-encoding = { version = "2", default-features = false }
+
+jsonwebtoken = { version = "9.3.0", default-features = false, features = ["use_pem"] }
+
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde_json = { version = "1", default-features = false }
+
+base64 = { version = "0.22.1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+
+dotenv = { version = "0.15", default-features = false }
+
+chrono = { version = "0.4", default-features = false, features = ["serde", "now"] }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "sync"] }
+futures-util = { version = "0.3", default_features = false, features = ["alloc"] }
+
+bytes = { version = "1.0", default-features = false }
+
+async-trait = { version = "0.1.48", default-features = false }
+
+openssl = { version = "0.10", default-features = false, optional = true }
+
+ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"], default-features = false, optional = true }
+
+pem = { version = "3.0.4", default-features = false, optional = true }
 
 [dev-dependencies]
-tokio =            { version = "1.0",  default-features = false, features = ["full"] }
+tokio = { version = "1.0", default-features = false, features = ["full"] }
 
 [package.metadata.docs.rs]
 features = ["global-client", "sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ ring = { version = "0.17.8", features = ["wasm32_unknown_unknown_js"], default-f
 
 pem = { version = "3.0.4", default-features = false, optional = true }
 
+web-time = "1.1.0"
+
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["full"] }
 

--- a/src/client/bucket.rs
+++ b/src/client/bucket.rs
@@ -36,7 +36,7 @@ impl<'a> BucketClient<'a> {
     /// ```
     pub async fn create(&self, new_bucket: &NewBucket) -> crate::Result<Bucket> {
         let url = format!("{}/b/", crate::BASE_URL);
-        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let project = self.0.token_cache.service_account().project_id;
         let query = [("project", project)];
         let result: GoogleResponse<Bucket> = self
             .0
@@ -74,7 +74,7 @@ impl<'a> BucketClient<'a> {
     /// ```
     pub async fn list(&self) -> crate::Result<Vec<Bucket>> {
         let url = format!("{}/b/", crate::BASE_URL);
-        let project = &crate::SERVICE_ACCOUNT.project_id;
+        let project = self.0.token_cache.service_account().project_id;
         let query = [("project", project)];
         let result: GoogleResponse<ListResponse<Bucket>> = self
             .0

--- a/src/client/hmac_key.rs
+++ b/src/client/hmac_key.rs
@@ -36,9 +36,9 @@ impl<'a> HmacKeyClient<'a> {
         let url = format!(
             "{}/projects/{}/hmacKeys",
             crate::BASE_URL,
-            crate::SERVICE_ACCOUNT.project_id
+            self.0.token_cache.service_account().project_id
         );
-        let query = [("serviceAccountEmail", &crate::SERVICE_ACCOUNT.client_email)];
+        let query = [("serviceAccountEmail", self.0.token_cache.service_account().client_email)];
         let mut headers = self.0.get_headers().await?;
         headers.insert(CONTENT_LENGTH, 0.into());
         let result: GoogleResponse<HmacKey> = self
@@ -82,7 +82,7 @@ impl<'a> HmacKeyClient<'a> {
         let url = format!(
             "{}/projects/{}/hmacKeys",
             crate::BASE_URL,
-            crate::SERVICE_ACCOUNT.project_id
+            self.0.token_cache.service_account().project_id
         );
         let response = self
             .0
@@ -132,7 +132,7 @@ impl<'a> HmacKeyClient<'a> {
         let url = format!(
             "{}/projects/{}/hmacKeys/{}",
             crate::BASE_URL,
-            crate::SERVICE_ACCOUNT.project_id,
+            self.0.token_cache.service_account().project_id,
             access_id
         );
         let result: GoogleResponse<HmacMeta> = self
@@ -174,7 +174,7 @@ impl<'a> HmacKeyClient<'a> {
         let url = format!(
             "{}/projects/{}/hmacKeys/{}",
             crate::BASE_URL,
-            crate::SERVICE_ACCOUNT.project_id,
+            self.0.token_cache.service_account().project_id,
             access_id
         );
         serde_json::to_string(&crate::hmac_key::UpdateMeta { state })?;
@@ -217,7 +217,7 @@ impl<'a> HmacKeyClient<'a> {
         let url = format!(
             "{}/projects/{}/hmacKeys/{}",
             crate::BASE_URL,
-            crate::SERVICE_ACCOUNT.project_id,
+            self.0.token_cache.service_account().project_id,
             access_id
         );
         let response = self

--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -84,6 +84,7 @@ impl<'a> ObjectClient<'a> {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn create_streamed<S>(
         &self,
         bucket: &str,

--- a/src/client/object.rs
+++ b/src/client/object.rs
@@ -84,7 +84,7 @@ impl<'a> ObjectClient<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub async fn create_streamed<S>(
         &self,
         bucket: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,11 +116,6 @@ lazy_static::lazy_static! {
     static ref IAM_TOKEN_CACHE: Mutex<Token> = Mutex::new(Token::new(
         "https://www.googleapis.com/auth/iam"
     ));
-
-    /// The struct is the parsed service account json file. It is publicly exported to enable easier
-    /// debugging of which service account is currently used. It is of the type
-    /// [ServiceAccount](service_account/struct.ServiceAccount.html).
-    pub static ref SERVICE_ACCOUNT: ServiceAccount = ServiceAccount::get();
 }
 
 #[cfg(feature = "global-client")]

--- a/src/resources/bucket.rs
+++ b/src/resources/bucket.rs
@@ -3,6 +3,7 @@ use crate::resources::{
     default_object_access_control::{DefaultObjectAccessControl, NewDefaultObjectAccessControl},
 };
 pub use crate::resources::{common::Entity, location::*};
+use crate::service_account::ServiceAccount;
 
 /// The Buckets resource represents a
 /// [bucket](https://cloud.google.com/storage/docs/key-terms#buckets) in Google Cloud Storage. There

--- a/src/resources/object.rs
+++ b/src/resources/object.rs
@@ -929,9 +929,9 @@ mod ring {
         };
 
         let key_pem = pem::parse(crate::SERVICE_ACCOUNT.private_key.as_bytes())?;
-        let key = RsaKeyPair::from_pkcs8(&key_pem.contents)?;
+        let key = RsaKeyPair::from_pkcs8(&key_pem.contents())?;
         let rng = SystemRandom::new();
-        let mut signature = vec![0; key.public_modulus_len()];
+        let mut signature = vec![0; key.public().modulus_len()];
         key.sign(&RSA_PKCS1_SHA256, &rng, message.as_bytes(), &mut signature)?;
         Ok(signature)
     }

--- a/src/resources/service_account.rs
+++ b/src/resources/service_account.rs
@@ -1,5 +1,5 @@
 /// A deserialized `service-account-********.json`-file.
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
 pub struct ServiceAccount {
     /// The type of authentication, this should always be `service_account`.
     #[serde(rename = "type")]

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,8 +2,8 @@ use std::fmt::{Display, Formatter};
 use async_trait::async_trait;
 
 /// Trait that refreshes a token when it is expired
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait TokenCache: Sync {
     /// Returns the token that is currently held within the instance of `TokenCache`, together with
     /// the expiry of that token as a u64 in seconds sine the Unix Epoch (1 Jan 1970).
@@ -86,8 +86,8 @@ impl Token {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl TokenCache for Token {
     async fn scope(&self) -> String {
         self.access_scope.clone()


### PR DESCRIPTION
Hey everybody,
the basic types from wasm_bindgen, which are used by reqwest etc. when compiling for wasm, are neither Send nor Sync. 

Since wasm is inherently single-threaded it is safe to send objects across "thread"-boundaries that do not implement these.

`asnyc_traits` however forces the parameters to be Sync + Send by default, this merge requests disables this only for wasm targets and should thus not effect anything else.

PS: I also bumped the versions of the dependencies